### PR TITLE
Add device-tree node path to the verbose output

### DIFF
--- a/lib/access.c
+++ b/lib/access.c
@@ -75,6 +75,7 @@ void pci_free_dev(struct pci_dev *d)
   pci_mfree(d->module_alias);
   pci_mfree(d->label);
   pci_mfree(d->phy_slot);
+  pci_mfree(d->dt_node);
   pci_mfree(d);
 }
 

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -137,6 +137,7 @@ struct pci_dev {
   char *phy_slot;			/* Physical slot */
   char *module_alias;			/* Linux kernel module alias */
   char *label;				/* Device name as exported by BIOS */
+  char *dt_node;			/* Path to the device-tree node for this device */
   int numa_node;			/* NUMA node */
   pciaddr_t flags[6];			/* PCI_IORESOURCE_* flags for regions */
   pciaddr_t rom_flags;			/* PCI_IORESOURCE_* flags for expansion ROM */
@@ -180,6 +181,7 @@ int pci_fill_info(struct pci_dev *, int flags) PCI_ABI; /* Fill in device inform
 #define PCI_FILL_LABEL		0x0400
 #define PCI_FILL_NUMA_NODE	0x0800
 #define PCI_FILL_IO_FLAGS	0x1000
+#define PCI_FILL_DT_NODE	0x2000
 #define PCI_FILL_RESCAN		0x00010000
 
 void pci_setup_cache(struct pci_dev *, u8 *cache, int len) PCI_ABI;

--- a/lspci.c
+++ b/lspci.c
@@ -685,7 +685,7 @@ show_verbose(struct device *d)
   show_terse(d);
 
   pci_fill_info(p, PCI_FILL_IRQ | PCI_FILL_BASES | PCI_FILL_ROM_BASE | PCI_FILL_SIZES |
-    PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE);
+    PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE);
   irq = p->irq;
 
   switch (htype)
@@ -716,6 +716,8 @@ show_verbose(struct device *d)
 
   if (verbose > 1)
     {
+      if (p->dt_node)
+        printf("\tDT Node: %s\n", p->dt_node);
       printf("\tControl: I/O%c Mem%c BusMaster%c SpecCycle%c MemWINV%c VGASnoop%c ParErr%c Stepping%c SERR%c FastB2B%c DisINTx%c\n",
 	     FLAG(cmd, PCI_COMMAND_IO),
 	     FLAG(cmd, PCI_COMMAND_MEMORY),
@@ -769,6 +771,8 @@ show_verbose(struct device *d)
     }
   else
     {
+      if (p->dt_node)
+        printf("\tDT Node: %s\n", p->dt_node);
       printf("\tFlags: ");
       if (cmd & PCI_COMMAND_MASTER)
 	printf("bus master, ");
@@ -867,7 +871,7 @@ show_machine(struct device *d)
 
   if (verbose)
     {
-      pci_fill_info(p, PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE);
+      pci_fill_info(p, PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE);
       printf((opt_machine >= 2) ? "Slot:\t" : "Device:\t");
       show_slot_name(d);
       putchar('\n');
@@ -894,6 +898,8 @@ show_machine(struct device *d)
 	show_kernel_machine(d);
       if (p->numa_node != -1)
 	printf("NUMANode:\t%d\n", p->numa_node);
+      if (p->dt_node)
+        printf("DTNode:\t%s\n", p->dt_node);
     }
   else
     {


### PR DESCRIPTION
Adds the path of the device-tree node of a PCI device to the lspci -v
output, like so:

0021:00:00.0 PCI bridge: IBM Device 03dc (prog-if 00 [Normal decode])
	DT Node: /sys/firmware/devicetree/base/pciex@3fffe41100000/pci@0

This is added as a generic property to struct pci_device and populated
by the sysfs backend. Other platforms may find it useful though.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>