### PR TITLE
lib/sysfs.c: use realpath instead of canonicalize_file_name.

### DIFF
--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -133,7 +133,7 @@ sysfs_deref_link(struct pci_dev *d, char *link_name)
   sysfs_obj_name(d, "", path);
   strcat(path, rel_path);
 
-  return canonicalize_file_name(path);
+  return realpath(path, NULL);
 }
 
 static int


### PR DESCRIPTION
both are the same and canonicalize_file_name is glibc specific, using
realpath allows pciutils to compile on musl libc systems like Void Linux
and Alpine Linux.