### PR TITLE
Enable setpci to target n-th capability of id

### DIFF
--- a/lib/caps.c
+++ b/lib/caps.c
@@ -104,11 +104,21 @@ pci_free_caps(struct pci_dev *d)
 struct pci_cap *
 pci_find_cap(struct pci_dev *d, unsigned int id, unsigned int type)
 {
+  return pci_find_cap_nr(d, id, type, 0);
+}
+
+struct pci_cap *
+pci_find_cap_nr(struct pci_dev *d, unsigned int id, unsigned int type, unsigned int cap_number)
+{
   struct pci_cap *c;
+  unsigned int num = 0;
 
   pci_fill_info_v35(d, ((type == PCI_CAP_NORMAL) ? PCI_FILL_CAPS : PCI_FILL_EXT_CAPS));
   for (c=d->first_cap; c; c=c->next)
-    if (c->type == type && c->id == id)
-      return c;
+     if (c->type == type && c->id == id)
+       if (num == cap_number)
+          return c;
+       else
+          num++;
   return NULL;
 }

--- a/lib/libpci.ver
+++ b/lib/libpci.ver
@@ -76,5 +76,9 @@ LIBPCI_3.5 {
 LIBPCI_3.6 {
 	global:
 		pci_get_string_property;
+};
+
+LIBPCI_3.7 {
+	global:
 		pci_find_cap_nr;
 };

--- a/lib/libpci.ver
+++ b/lib/libpci.ver
@@ -76,4 +76,5 @@ LIBPCI_3.5 {
 LIBPCI_3.6 {
 	global:
 		pci_get_string_property;
+		pci_find_cap_nr;
 };

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -212,7 +212,7 @@ struct pci_cap {
 
 struct pci_cap *pci_find_cap(struct pci_dev *, unsigned int id, unsigned int type) PCI_ABI;
 struct pci_cap *pci_find_cap_nr(struct pci_dev *, unsigned int id, unsigned int type,
-                             unsigned int cap_number) PCI_ABI;
+                             unsigned int *cap_number) PCI_ABI;
 
 /*
  *	Filters

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -211,6 +211,8 @@ struct pci_cap {
 #define PCI_CAP_EXTENDED	2	/* PCIe extended capabilities */
 
 struct pci_cap *pci_find_cap(struct pci_dev *, unsigned int id, unsigned int type) PCI_ABI;
+struct pci_cap *pci_find_cap_nr(struct pci_dev *, unsigned int id, unsigned int type,
+                             unsigned int cap_number) PCI_ABI;
 
 /*
  *	Filters

--- a/setpci.c
+++ b/setpci.c
@@ -36,6 +36,7 @@ struct op {
   unsigned int addr;
   unsigned int width;			/* Byte width of the access */
   unsigned int num_values;		/* Number of values to write; 0=read */
+  unsigned int number;                 /* The n-th capability of that id */
   struct value values[0];
 };
 
@@ -84,11 +85,13 @@ exec_op(struct op *op, struct pci_dev *dev)
   if (op->cap_type)
     {
       struct pci_cap *cap;
-      cap = pci_find_cap(dev, op->cap_id, op->cap_type);
+      cap = pci_find_cap_nr(dev, op->cap_id, op->cap_type, op->number);
       if (cap)
-	addr = cap->addr;
+        addr = cap->addr;
       else
-	die("%s: %s %04x not found", slot, ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"), op->cap_id);
+        die("%s: %d%s %s %04x not found", slot,
+            op->number, (op->number % 10 == 1) ? "st" : (op->number % 10 == 2) ? "nd" : "th",
+            ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"), op->cap_id);
       trace(((op->cap_type == PCI_CAP_NORMAL) ? "(cap %02x @%02x) " : "(ecap %04x @%03x) "), op->cap_id, addr);
     }
   addr += op->addr;
@@ -341,7 +344,7 @@ GENERIC_HELP
 "Setting commands:\n"
 "<device>:\t-s [[[<domain>]:][<bus>]:][<slot>][.[<func>]]\n"
 "\t\t-d [<vendor>]:[<device>]\n"
-"<reg>:\t\t<base>[+<offset>][.(B|W|L)]\n"
+"<reg>:\t\t<base>[+<offset>][.(B|W|L)][@<number>]\n"
 "<base>:\t\t<address>\n"
 "\t\t<named-register>\n"
 "\t\t[E]CAP_<capability-name>\n"
@@ -557,7 +560,7 @@ static void parse_register(struct op *op, char *base)
 
 static void parse_op(char *c, struct pci_dev **selected_devices)
 {
-  char *base, *offset, *width, *value;
+  char *base, *offset, *width, *value, *number;
   char *e, *f;
   int n, j;
   struct op *op;
@@ -566,6 +569,8 @@ static void parse_op(char *c, struct pci_dev **selected_devices)
   base = xstrdup(c);
   if (value = strchr(base, '='))
     *value++ = 0;
+  if (number = strchr(base, '@'))
+    *number++ = 0;
   if (width = strchr(base, '.'))
     *width++ = 0;
   if (offset = strchr(base, '+'))
@@ -607,6 +612,18 @@ static void parse_op(char *c, struct pci_dev **selected_devices)
     }
   else
     op->width = 0;
+
+  /* Check which n-th capability of the same id we want */
+  if (number)
+    {
+      unsigned int num;
+      if (parse_x32(number, NULL, &num) <= 0 || (int) num < 0)
+          parse_err("Invalid number \"%s\"", number);
+      op->number = num;
+
+    }
+  else
+      op->number = 0;
 
   /* Find the register */
   parse_register(op, base);

--- a/setpci.c
+++ b/setpci.c
@@ -85,13 +85,19 @@ exec_op(struct op *op, struct pci_dev *dev)
   if (op->cap_type)
     {
       struct pci_cap *cap;
-      cap = pci_find_cap_nr(dev, op->cap_id, op->cap_type, op->number);
+      unsigned int cap_nr = op->number;
+      cap = pci_find_cap_nr(dev, op->cap_id, op->cap_type, &cap_nr);
       if (cap)
         addr = cap->addr;
+      else if (cap_nr == 0)
+        die("%s: Instance #%d of %s %04x not found - there are no capabilities with that id.", slot,
+            op->number, ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"),
+            op->cap_id);
       else
-        die("%s: %d%s %s %04x not found", slot,
-            op->number, (op->number % 10 == 1) ? "st" : (op->number % 10 == 2) ? "nd" : "th",
-            ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"), op->cap_id);
+        die("%s: Instance #%d of %s %04x not found - there %s only %d capability with that id.", slot,
+            op->number, ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"),
+            op->cap_id, ((cap_nr == 1) ? "is" : "are"), cap_nr);
+
       trace(((op->cap_type == PCI_CAP_NORMAL) ? "(cap %02x @%02x) " : "(ecap %04x @%03x) "), op->cap_id, addr);
     }
   addr += op->addr;

--- a/setpci.man
+++ b/setpci.man
@@ -148,9 +148,12 @@ Each of the previous formats can be followed by \fB+offset\fP to add an offset
 (a hex number) to the address. This feature can be useful for addressing of registers
 living within a capability, or to modify parts of standard registers.
 .IP \(bu
-Finally, you should append a width specifier \fB.B\fP, \fB.W\fP, or \fB.L\fP to choose
-how many bytes (1, 2, or 4) should be transferred. The width can be omitted if you are
+To choose how many bytes (1, 2, or 4) should be transferred, you should append a width
+specifier \fB.B\fP, \fB.W\fP, or \fB.L\fP. The width can be omitted if you are
 referring to a register by its name and the width of the register is well known.
+.IP \(bu
+Finally, if a capability exists multiple times you can choose which one to target using
+\fB@number\fP. Indexing starts at 0.
 
 .PP
 All names of registers and width specifiers are case-insensitive.


### PR DESCRIPTION
Because a capability can exist multiple times with the same id
there needs to be a way to target a specific one. Instead of
the current behaviour which always targets the first one.
Now you can optionally add `@number` (e.g `@1`) after the width to
choose which one to target.

Please let me know what you think :)