### PR TITLE
Fix solaris build

### DIFF
--- a/lib/names-net.c
+++ b/lib/names-net.c
@@ -15,6 +15,14 @@
 
 #ifdef PCI_USE_DNS
 
+/*
+ * Our definition of BYTE_ORDER confuses arpa/nameser_compat.h on
+ * Solaris so we must undef it before including arpa/nameser.h.
+ */
+#ifdef PCI_OS_SUNOS
+#undef BYTE_ORDER
+#endif
+
 #include <netinet/in.h>
 #include <arpa/nameser.h>
 #include <resolv.h>


### PR DESCRIPTION
Defining BYTE_ORDER on Solaris breaks the arpa headers.