### PR TITLE
 Fix regression of refactoring in d7d9e30 

### DIFF
--- a/lib/caps.c
+++ b/lib/caps.c
@@ -113,8 +113,8 @@ pci_find_cap(struct pci_dev *d, unsigned int id, unsigned int type)
  * To select one capability if there are more than one with the same id, you
  * can provide a pointer to an unsigned int that contains the index which you
  * want as cap_number. If you don't care and are fine with the first one you
- * can supply NULL. The cap_number will be replaced by the acutal number
- * of capablities with that id.
+ * can supply NULL. The cap_number will be replaced by the actual number of
+ * capablities with that id.
  */
 struct pci_cap *
 pci_find_cap_nr(struct pci_dev *d, unsigned int id, unsigned int type,
@@ -130,11 +130,13 @@ pci_find_cap_nr(struct pci_dev *d, unsigned int id, unsigned int type,
   for (c=d->first_cap; c; c=c->next)
     {
       if (c->type == type && c->id == id)
-	{
-	  if (target == index)
-	    found = c;
-	}
-      index++;
+        {
+          if (target == index)
+            {
+              found = c;
+            }
+          index++;
+        }
     }
 
   if (cap_number)

--- a/setpci.c
+++ b/setpci.c
@@ -94,9 +94,10 @@ exec_op(struct op *op, struct pci_dev *dev)
             op->number, ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"),
             op->cap_id);
       else
-        die("%s: Instance #%d of %s %04x not found - there %s only %d capability with that id.", slot,
+        die("%s: Instance #%d of %s %04x not found - there %s only %d %s with that id.", slot,
             op->number, ((op->cap_type == PCI_CAP_NORMAL) ? "Capability" : "Extended capability"),
-            op->cap_id, ((cap_nr == 1) ? "is" : "are"), cap_nr);
+            op->cap_id, ((cap_nr == 1) ? "is" : "are"), cap_nr,
+            ((cap_nr == 1) ? "capability" : "capabilities"));
 
       trace(((op->cap_type == PCI_CAP_NORMAL) ? "(cap %02x @%02x) " : "(ecap %04x @%03x) "), op->cap_id, addr);
     }


### PR DESCRIPTION
The refactoring done while merging #7 introduced a bug, which is fixed with this.
But you also fixed a mistake I made, by returning out of the loop to early. That caused `cap_number` not to be set correctly when the capability was found. Thanks

I also changed the format in setpci to correctly pluralize 'capability' when needed.