### PR TITLE
 Set PCI_HAVE_64BIT_ADDRESS for NetBSD.

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -116,6 +116,7 @@ case $sys in
 		echo_n " nbsd-libpci"
 		echo >>$c '#define PCI_HAVE_PM_NBSD_LIBPCI'
 		echo >>$c '#define PCI_PATH_NBSD_DEVICE "/dev/pci0"'
+		echo >>$c '#define PCI_HAVE_64BIT_ADDRESS'
 		echo >>$m 'LIBNAME=libpciutils'
 		echo >>$m 'WITH_LIBS+=-lpci'
 		LIBRESOLV=


### PR DESCRIPTION
When I set "Over 4G decoding" in a BIOS setting and boot NetBSD machine,
I've noticed that lspci reports:
    pcilib: 0000:07:00.0 64-bit device address ignored.
and
    Region 0: Memory at <ignored> (64-bit, prefetchable)

After applying this change:
    Region 0: Memory at 7d7f600000 (64-bit, prefetchable)

