### PR TITLE
libpci.pc.in: Use prefixes instead of hardcoding

### DIFF
--- a/lib/libpci.pc.in
+++ b/lib/libpci.pc.in
@@ -1,7 +1,8 @@
 prefix=@PREFIX@
-includedir=@INCDIR@
+exec_prefix=@PREFIX@
+includedir=${prefix}/include
 libdir=@LIBDIR@
-idsdir=@IDSDIR@
+idsdir=${prefix}/share
 
 Name: libpci
 Description: libpci


### PR DESCRIPTION
This makes it more cross compile friendly.

Still need a solution for libdir since it can be either lib or lib64 (and maybe lib32).