### PR TITLE
lspci: Avoid printing null character in VPD fields

### DIFF
--- a/ls-vpd.c
+++ b/ls-vpd.c
@@ -178,7 +178,7 @@ cap_vpd(struct device *d)
 	      if (!read_vpd(d, res_addr + part_pos, buf, read_len, &csum))
 		break;
 
-	      printf("\t\t\t[%c%c] %s: ", id1, id2, item->name);
+	      printf("\t\t\t[%.1s%.1s] %s: ", &id1, &id2, item->name);
 
 	      switch (item->format)
 	        {


### PR DESCRIPTION
An 'Unknown' VPD field with 0x0 id is translated to an ascii NULL character
by printf() %c format specifier. This makes for some ugly output and tools
such as gawk will throw a warning when parsing it.

Avoid this by using the %s format specifier with a length limit of 1.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>