### PR TITLE
lspci: Print IOMMU groups with -v

### DIFF
--- a/lib/pci.h
+++ b/lib/pci.h
@@ -204,6 +204,7 @@ char *pci_get_string_property(struct pci_dev *d, u32 prop) PCI_ABI;
 #define PCI_FILL_NUMA_NODE	0x0800
 #define PCI_FILL_IO_FLAGS	0x1000
 #define PCI_FILL_DT_NODE	0x2000		/* Device tree node */
+#define PCI_FILL_IOMMU_GROUP	0x4000
 #define PCI_FILL_RESCAN		0x00010000
 
 void pci_setup_cache(struct pci_dev *, u8 *cache, int len) PCI_ABI;

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -354,6 +354,16 @@ sysfs_fill_info(struct pci_dev *d, unsigned int flags)
       done |= PCI_FILL_NUMA_NODE;
     }
 
+  if (flags & PCI_FILL_IOMMU_GROUP)
+    {
+      char *group_link = sysfs_deref_link(d, "iommu_group");
+      if (group_link)
+        {
+          pci_set_property(d, PCI_FILL_IOMMU_GROUP, basename(group_link));
+          free(group_link);
+        }
+    }
+
   if (flags & PCI_FILL_DT_NODE)
     {
       char *node = sysfs_deref_link(d, "of_node");

--- a/lspci.c
+++ b/lspci.c
@@ -725,12 +725,12 @@ show_verbose(struct device *d)
   byte max_lat, min_gnt;
   byte int_pin = get_conf_byte(d, PCI_INTERRUPT_PIN);
   unsigned int irq;
-  char *dt_node;
+  char *dt_node, *iommu_group;
 
   show_terse(d);
 
   pci_fill_info(p, PCI_FILL_IRQ | PCI_FILL_BASES | PCI_FILL_ROM_BASE | PCI_FILL_SIZES |
-    PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE);
+    PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE | PCI_FILL_IOMMU_GROUP);
   irq = p->irq;
 
   switch (htype)
@@ -814,6 +814,8 @@ show_verbose(struct device *d)
 	       (int_pin ? 'A' + int_pin - 1 : '?'), irq);
       if (p->numa_node != -1)
 	printf("\tNUMA node: %d\n", p->numa_node);
+      if (iommu_group = pci_get_string_property(p, PCI_FILL_IOMMU_GROUP))
+	printf("\tIOMMU group: %s\n", iommu_group);
     }
   else
     {
@@ -840,6 +842,8 @@ show_verbose(struct device *d)
 	printf(", IRQ " PCIIRQ_FMT, irq);
       if (p->numa_node != -1)
 	printf(", NUMA node %d", p->numa_node);
+      if (iommu_group = pci_get_string_property(p, PCI_FILL_IOMMU_GROUP))
+	printf(", IOMMU group %s", iommu_group);
       putchar('\n');
     }
 
@@ -910,13 +914,13 @@ show_machine(struct device *d)
   int c;
   word sv_id, sd_id;
   char classbuf[128], vendbuf[128], devbuf[128], svbuf[128], sdbuf[128];
-  char *dt_node;
+  char *dt_node, *iommu_group;
 
   get_subid(d, &sv_id, &sd_id);
 
   if (verbose)
     {
-      pci_fill_info(p, PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE);
+      pci_fill_info(p, PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE | PCI_FILL_IOMMU_GROUP);
       printf((opt_machine >= 2) ? "Slot:\t" : "Device:\t");
       show_slot_name(d);
       putchar('\n');
@@ -945,6 +949,8 @@ show_machine(struct device *d)
 	printf("NUMANode:\t%d\n", p->numa_node);
       if (dt_node = pci_get_string_property(p, PCI_FILL_DT_NODE))
         printf("DTNode:\t%s\n", dt_node);
+      if (iommu_group = pci_get_string_property(p, PCI_FILL_IOMMU_GROUP))
+	printf("IOMMUGroup:\t%s\n", iommu_group);
     }
   else
     {

--- a/lspci.man
+++ b/lspci.man
@@ -316,6 +316,10 @@ Kernel module reporting that it is capable of handling the device
 .B NUMANode
 NUMA node this device is connected to (optional, Linux only).
 
+.TP
+.B IOMMUGroup
+IOMMU group that this device is part of (optional, Linux only).
+
 .P
 New tags can be added in future versions, so you should silently ignore any tags you don't recognize.
 


### PR DESCRIPTION
PCI passthrough is increasingly popular. This makes it a little bit easier.

It doesn't seem to actually work properly though... it only works with -vv, and it doesn't work with -mmvv, and I can't figure out why.