### PR TITLE
update-pciids.sh: apply Shellcheck recommendations

### DIFF
--- a/update-pciids.sh
+++ b/update-pciids.sh
@@ -6,7 +6,7 @@ set -e
 SRC="https://pci-ids.ucw.cz/v2.2/pci.ids"
 DEST=pci.ids
 PCI_COMPRESSED_IDS=
-GREP=grep
+GREP="grep"
 
 # if pci.ids is read-only (because the filesystem is read-only),
 # then just skip this whole process.
@@ -18,24 +18,24 @@ fi
 if [ "$PCI_COMPRESSED_IDS" = 1 ] ; then
 	DECOMP="cat"
 	SRC="$SRC.gz"
-	GREP=zgrep
-elif which bzip2 >/dev/null 2>&1 ; then
+	GREP="zgrep"
+elif command -v bzip2 >/dev/null 2>&1 ; then
 	DECOMP="bzip2 -d"
 	SRC="$SRC.bz2"
-elif which gzip >/dev/null 2>&1 ; then
+elif command -v gzip >/dev/null 2>&1 ; then
 	DECOMP="gzip -d"
 	SRC="$SRC.gz"
 else
 	DECOMP="cat"
 fi
 
-if which curl >/dev/null 2>&1 ; then
+if command -v curl >/dev/null 2>&1 ; then
 	DL="curl -o $DEST.new $SRC"
     ${quiet} && DL="$DL -s -S"
-elif which wget >/dev/null 2>&1 ; then
+elif command -v wget >/dev/null 2>&1 ; then
 	DL="wget --no-timestamping -O $DEST.new $SRC"
 	${quiet} && DL="$DL -q"
-elif which lynx >/dev/null 2>&1 ; then
+elif command -v lynx >/dev/null 2>&1 ; then
 	DL="eval lynx -source $SRC >$DEST.new"
 else
 	echo >&2 "update-pciids: cannot find curl, wget or lynx"


### PR DESCRIPTION
Shellcheck complains both about assigning strings without quotation and
the usage of `which` instead of `command -v`, which is a shell built in
command.

Getting rid of the latter is particularly interesting to lose the
busybox `which` dependency in OpenWrt, saving storage on embedded
devices.

Signed-off-by: Paul Spooren <mail@aparcar.org>