### PR TITLE
Added five nibbles for domain in dump read

### DIFF
--- a/lib/dump.c
+++ b/lib/dump.c
@@ -80,7 +80,8 @@ dump_init(struct pci_access *a)
       len = z - buf + 1;
       mn = 0;
       if (dump_validate(buf, "##:##.# ") && sscanf(buf, "%x:%x.%d", &bn, &dn, &fn) == 3 ||
-	  dump_validate(buf, "####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4)
+	  dump_validate(buf, "####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4 ||
+	  dump_validate(buf, "#####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4)
 	{
 	  dev = pci_get_dev(a, mn, bn, dn, fn);
 	  dump_alloc_data(dev, 256);


### PR DESCRIPTION
Allow five nibbles as valid domain, when reading from a dump file with
domain