### PR TITLE
Fixed MSAN errnum use-of-uninitialized value warning. 

### DIFF
--- a/lib/names-parse.c
+++ b/lib/names-parse.c
@@ -42,7 +42,7 @@ static pci_file pci_open(struct pci_access *a)
 #define pci_close(f)		gzclose(f)
 #define PCI_ERROR(f, err)						\
 	if (!err) {							\
-		int errnum;						\
+		int errnum = 0;						\
 		gzerror(f, &errnum);					\
 		if (errnum >= 0) err = NULL;				\
 		else if (errnum == Z_ERRNO) err = "I/O error";		\


### PR DESCRIPTION
[gzerror](https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/gzlib.c#L532) is not guaranteed to set `errnum` so we initialized it to 0.
```
1: ==30801==WARNING: MemorySanitizer: use-of-uninitialized-value
1:     #0 0x7f26e03b3fea in pci_load_name_list ./instrumented_libraries/libpci3/pciutils-3.2.1/lib/names-parse.c:228:3
1:     #1 0x7f26e03a9cb2 in pci_lookup_name ./instrumented_libraries/libpci3/pciutils-3.2.1/lib/names.c:134:5
1: 
1:   Uninitialized value was created by an allocation of 'errnum' in the stack frame of function 'pci_load_name_list'
1:     #0 0x7f26e03b1020 in pci_load_name_list ./instrumented_libraries/libpci3/pciutils-3.2.1/lib/names-parse.c:218
1: 
1: SUMMARY: MemorySanitizer: use-of-uninitialized-value ./instrumented_libraries/libpci3/pciutils-3.2.1/lib/names-parse.c:228:3 in pci_load_name_list
```