### PR TITLE
add missing symlinks to libraries in install-lib target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,10 @@ install-lib: $(PCIINC_INS) lib/$(PCILIBPC) install-pcilib
 	$(INSTALL) -c -m 644 lib/$(PCILIBPC) $(DESTDIR)$(PKGCFDIR)
 ifeq ($(SHARED),yes)
 ifeq ($(LIBEXT),dylib)
+	ln -sf $(PCILIB) $(DESTDIR)$(LIBDIR)/$(LIBNAME)$(ABI_VERSION).$(LIBEXT)
 	ln -sf $(LIBNAME)$(ABI_VERSION).$(LIBEXT) $(DESTDIR)$(LIBDIR)/$(LIBNAME).$(LIBEXT)
 else
+	ln -sf $(PCILIB) $(DESTDIR)$(LIBDIR)/$(LIBNAME).$(LIBEXT)$(ABI_VERSION)
 	ln -sf $(LIBNAME).$(LIBEXT)$(ABI_VERSION) $(DESTDIR)$(LIBDIR)/$(LIBNAME).$(LIBEXT)
 endif
 endif


### PR DESCRIPTION
The `install-lib` target results in a broken installation because it only symlinks `libpci.so` to `libpci.so.$(ABI_VERSION)`, but `libpci.so.$(ABI_VERSION)` does not exist. This PR adds the missing symlink between `libpci.so.$(ABI_VERSION)` and the actual library file.