### PR TITLE
ls-kernel: fix memory leak in show_kernel_init

### DIFF
--- a/ls-kernel.c
+++ b/ls-kernel.c
@@ -160,7 +160,10 @@ show_kernel_init(void)
 		 &e->vendor, &e->device,
 		 &e->subvendor, &e->subdevice,
 		 &e->class, &e->class_mask) != 6)
-	continue;
+	{
+	  free(e);
+	  continue;
+	}
       e->next = pcimap_head;
       pcimap_head = e;
       strcpy(e->module, line);


### PR DESCRIPTION
The pointer e will not be free if continue. Fix it.

Signed-off-by:Lixiaokeng <lixiaokeng@huawei.com>