### PR TITLE
setpci: fix memory leak in select_devices

### DIFF
--- a/setpci.c
+++ b/setpci.c
@@ -70,6 +70,8 @@ select_devices(struct group *group)
       int i = 0;
       if (pci_filter_match(f, dev))
 	devs[i++] = dev;
+      else
+        pci_free_dev(dev);
       devs[i] = NULL;
       return devs;
     }


### PR DESCRIPTION
The pci_get_dev will malloc some memory to dev. If
dev is not stored to devs, free it before return.

Signed-off-by:Lixiaokeng <lixiaokeng@huawei.com>