### PR TITLE
Fix compilation of source files with MinGW

### DIFF
--- a/compat/getopt.c
+++ b/compat/getopt.c
@@ -36,7 +36,6 @@
 #endif
 
 #include <stdio.h>
-#include <string.h>
 
 /* Comment out all this code if we are using the GNU C Library, and are not
    actually compiling the library itself.  This code is part of the GNU C
@@ -163,6 +162,8 @@ static enum {
 #include <string.h>
 #define	my_index	strchr
 #define	my_strlen	strlen
+#define	my_strcmp	strcmp
+#define	my_strncmp	strncmp
 #else
 
 /* Avoid depending on library functions or files
@@ -170,11 +171,11 @@ static enum {
 
 #if __STDC__ || defined(PROTO)
 extern char *getenv(const char *name);
-extern int strcmp(const char *s1, const char *s2);
-extern int strncmp(const char *s1, const char *s2, int n);
 
 static int my_strlen(const char *s);
 static char *my_index(const char *str, int chr);
+static int my_strncmp(const char *s1, const char *s2, int n);
+static int my_strcmp(const char *s1, const char *s2);
 #else
 extern char *getenv();
 #endif
@@ -195,6 +196,23 @@ static char *my_index(const char *str, int chr)
 		str++;
 	}
 	return 0;
+}
+
+static int my_strncmp(const char *s1, const char *s2, int n)
+{
+	while (n && *s1 && (*s1 == *s2)) {
+		++s1;
+		++s2;
+		--n;
+	}
+	if (n == 0)
+		return 0;
+	return *(const unsigned char *)s1 - *(const unsigned char *)s2;
+}
+
+static int my_strcmp(const char *s1, const char *s2)
+{
+	return my_strncmp(s1, s2, -1);
 }
 
 #endif				/* GNU C library.  */
@@ -385,7 +403,7 @@ int _getopt_internal(int argc, char *const *argv, const char *optstring,
 		   then exchange with previous non-options as if it were an option,
 		   then skip everything else like a non-option.  */
 
-		if (optind != argc && !strcmp(argv[optind], "--")) {
+		if (optind != argc && !my_strcmp(argv[optind], "--")) {
 			optind++;
 
 			if (first_nonopt != last_nonopt && last_nonopt != optind)
@@ -445,7 +463,7 @@ int _getopt_internal(int argc, char *const *argv, const char *optstring,
 
 		/* Test all options for either exact match or abbreviated matches.  */
 		for (p = longopts, option_index = 0; p->name; p++, option_index++)
-			if (!strncmp(p->name, nextchar, s - nextchar)) {
+			if (!my_strncmp(p->name, nextchar, s - nextchar)) {
 				if (s - nextchar == my_strlen(p->name)) {
 					/* Exact match found.  */
 					pfound = p;

--- a/compat/getopt.h
+++ b/compat/getopt.h
@@ -95,12 +95,7 @@ struct option
 #define optional_argument	2
 
 #if __STDC__ || defined(PROTO)
-#if defined(__GNU_LIBRARY__)
-/* Many other libraries have conflicting prototypes for getopt, with
-   differences in the consts, in stdlib.h.  To avoid compilation
-   errors, only prototype getopt for the GNU C library.  */
 extern int getopt (int argc, char *const *argv, const char *shortopts);
-#endif /* not __GNU_LIBRARY__ */
 extern int getopt_long (int argc, char *const *argv, const char *shortopts,
 		        const struct option *longopts, int *longind);
 extern int getopt_long_only (int argc, char *const *argv,

--- a/lib/sysdep.h
+++ b/lib/sysdep.h
@@ -21,7 +21,7 @@ typedef u8 byte;
 typedef u16 word;
 
 #ifdef PCI_OS_WINDOWS
-#define strcasecmp strcmpi
+#define strcasecmp _strcmpi
 #endif
 
 #ifdef PCI_HAVE_LINUX_BYTEORDER_H

--- a/ls-ecaps.c
+++ b/ls-ecaps.c
@@ -653,8 +653,9 @@ cap_rcec(struct device *d, int where)
       int prevmatched=0;
       int adjcount=0;
       int prevdev=0;
+      int dev;
       printf("RCiEP at Device(s):");
-      for (int dev=0; dev < 32; dev++)
+      for (dev=0; dev < 32; dev++)
         {
 	  if (BITS(bmap, dev, 1))
 	    {

--- a/ls-tree.c
+++ b/ls-tree.c
@@ -170,6 +170,8 @@ tree_printf(char *line, char *p, char *fmt, ...)
   int res = vsnprintf(p, end - p, fmt, args);
   if (res < 0)
     {
+      /* msvcrt _vsnprintf() does not set nul-term byte */
+      *end = '\0';
       /* Ancient C libraries return -1 on overflow */
       p += strlen(p);
     }

--- a/pciutils.h
+++ b/pciutils.h
@@ -9,7 +9,20 @@
 #include "lib/pci.h"
 #include "lib/sysdep.h"
 
-#ifdef PCI_OS_WINDOWS
+/*
+ * gcc predefines macro __MINGW32__ for all MinGW targets.
+ * Including some MinGW header (e.g. windef.h) defines additional
+ * macro __MINGW32_MAJOR_VERSION (available for all MinGW targets).
+ */
+#if defined(PCI_OS_WINDOWS) && defined(__MINGW32__)
+#include <windef.h>
+#endif
+
+/*
+ * On Windows only MinGW 3.0 and higher versions provides <getopt.h>
+ * header file. Older MinGW versions and MSVC do not have it.
+ */
+#if defined(PCI_OS_WINDOWS) && !(defined(__MINGW32_MAJOR_VERSION) && __MINGW32_MAJOR_VERSION >= 3)
 #include "compat/getopt.h"
 #else
 #include <unistd.h>


### PR DESCRIPTION
Improve compat/getopt.c implementation, fix usage of vsnprintf() and strcasecmp() functions with MSVCRT runtime and fix compile errors.