### PR TITLE
libpci: For PCI_OS_WINDOWS allows to load pci.ids from executable directory

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -9,7 +9,7 @@ echo_n() {
 	printf '%s' "$*"
 }
 
-if [ -z "$VERSION" -o -z "$IDSDIR" ] ; then
+if [ -z "$VERSION" ] ; then
 	echo >&2 "Please run the configure script from the top-level Makefile"
 	exit 1
 fi


### PR DESCRIPTION
With compile option PCI_PATH_IDS_DIR="" loads pci.ids on Windows from the executable directory.