### PR TITLE
Add PCIe 3.0+ decoding of the LnkCtl2 Compliance Preset/De-emphasis field

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -917,7 +917,7 @@
 #define  PCI_EXP_LNKCTL2_MARGIN(x)	(((x) >> 7) & 7) /* Transmit Margin */
 #define  PCI_EXP_LNKCTL2_MOD_CMPLNC	0x0400	/* Enter Modified Compliance */
 #define  PCI_EXP_LNKCTL2_CMPLNC_SOS	0x0800	/* Compliance SOS */
-#define  PCI_EXP_LNKCTL2_COM_DEEMPHASIS(x) (((x) >> 12) & 0xf) /* Compliance De-emphasis */
+#define  PCI_EXP_LNKCTL2_COM_DEEMPHASIS(x) (((x) >> 12) & 0xf) /* Compliance Preset/De-emphasis */
 #define PCI_EXP_LNKSTA2			0x32	/* Link Status */
 #define  PCI_EXP_LINKSTA2_DEEMPHASIS(x)	((x) & 1)	/* Current De-emphasis Level */
 #define  PCI_EXP_LINKSTA2_EQU_COMP	0x02	/* Equalization Complete */

--- a/ls-caps.c
+++ b/ls-caps.c
@@ -1233,6 +1233,35 @@ static const char *cap_express_link2_deemphasis(int type)
     }
 }
 
+static const char *cap_express_link2_compliance_preset(int type)
+{
+  switch (type)
+    {
+      case 0:
+	return "-6dB de-emphasis, 0dB preshoot";
+      case 1:
+	return "-3.5dB de-emphasis, 0dB preshoot";
+      case 2:
+	return "-4.4dB de-emphasis, 0dB preshoot";
+      case 3:
+	return "-2.5dB de-emphasis, 0dB preshoot";
+      case 4:
+	return "0dB de-emphasis, 0dB preshoot";
+      case 5:
+	return "0dB de-emphasis, 1.9dB preshoot";
+      case 6:
+	return "0dB de-emphasis, 2.5dB preshoot";
+      case 7:
+	return "-6.0dB de-emphasis, 3.5dB preshoot";
+      case 8:
+	return "-3.5dB de-emphasis, 3.5dB preshoot";
+      case 9:
+	return "0dB de-emphasis, 3.5dB preshoot";
+      default:
+	return "Unknown";
+    }
+}
+
 static const char *cap_express_link2_transmargin(int type)
 {
   switch (type)
@@ -1314,11 +1343,11 @@ static void cap_express_link2(struct device *d, int where, int type)
 	cap_express_link2_deemphasis(PCI_EXP_LNKCTL2_DEEMPHASIS(w)));
     printf("\n"
 	"\t\t\t Transmit Margin: %s, EnterModifiedCompliance%c ComplianceSOS%c\n"
-	"\t\t\t Compliance De-emphasis: %s\n",
+	"\t\t\t Compliance Preset/De-emphasis: %s\n",
 	cap_express_link2_transmargin(PCI_EXP_LNKCTL2_MARGIN(w)),
 	FLAG(w, PCI_EXP_LNKCTL2_MOD_CMPLNC),
 	FLAG(w, PCI_EXP_LNKCTL2_CMPLNC_SOS),
-	cap_express_link2_deemphasis(PCI_EXP_LNKCTL2_COM_DEEMPHASIS(w)));
+	cap_express_link2_compliance_preset(PCI_EXP_LNKCTL2_COM_DEEMPHASIS(w)));
   }
 
   w = get_conf_word(d, where + PCI_EXP_LNKSTA2);


### PR DESCRIPTION
As of PCIe 3.0, the LnkCtl2 "Compliance De-emphasis" field has been
renamed to "Compliance Preset/De-emphasis", and there are several new
bit encodings for various de-emphasis and preshoot combinations.

The name of the PCI_EXP_LNKCTL2_COM_DEEMPHASIS() macro is not changed
by this commit, as it is part of the libpci API.

Reported-by: Tim CC Chen(陳志佳) <Tim.CC.Chen@wnc.com.tw>
Signed-off-by: Lennert Buytenhek <buytenh@arista.com>