### PR TITLE
libpci: i386-io-windows.h: Mute false-positive warning

### DIFF
--- a/lib/i386-io-windows.h
+++ b/lib/i386-io-windows.h
@@ -1031,6 +1031,7 @@ SetProcessUserModeIOPL(VOID)
   impersonate_privilege_enabled = FALSE;
   revert_to_old_token = FALSE;
   lsass_token = NULL;
+  old_token = NULL;
 
   /* Fast path when ProcessUserModeIOPL was already called. */
   if (read_iopl() == 3)


### PR DESCRIPTION
  i386-ports.c: In function ‘conf12_setup_io’:
  i386-io-windows.h:1021: warning: ‘old_token’ may be used uninitialized in this function
  i386-io-windows.h:1021: note: ‘old_token’ was declared here

It is always properly initialized when accessed, just gcc compiler does not see it.