### PR TITLE
i386-ports: Do not mark pci_access in conf12_cleanup() as unused

### DIFF
--- a/lib/i386-ports.c
+++ b/lib/i386-ports.c
@@ -51,7 +51,7 @@ conf12_init(struct pci_access *a)
 }
 
 static void
-conf12_cleanup(struct pci_access *a UNUSED)
+conf12_cleanup(struct pci_access *a)
 {
   if (conf12_io_enabled > 0)
     {


### PR DESCRIPTION
It is used as argument for intel_cleanup_io() function.