### PR TITLE
lspci: Show hex dump parsed with -X option.

### DIFF
--- a/lspci.c
+++ b/lspci.c
@@ -49,6 +49,7 @@ static char help_msg[] =
 "-x\t\tShow hex-dump of the standard part of the config space\n"
 "-xxx\t\tShow hex-dump of the whole config space (dangerous; root only)\n"
 "-xxxx\t\tShow hex-dump of the 4096-byte extended config space (root only)\n"
+"-X\t\tShow parsed hex-dump of the standard part of the config space\n"
 "-b\t\tBus-centric view (addresses and IRQ's as seen by the bus)\n"
 "-D\t\tAlways show domain numbers\n"
 "-P\t\tDisplay bridge path in addition to bus and device number\n"
@@ -225,6 +226,8 @@ compare_them(const void *A, const void *B)
     return 1;
   return 0;
 }
+
+
 
 static void
 sort_them(void)
@@ -908,41 +911,155 @@ show_hex_parsed(struct device *d)
       if (opt_hex_parsed >= 4 && config_fetch(d, 256, 4096-256))
 	cnt = 4096;
     }
-  
+
   for (i=0; i<cnt; i++)
     {
-          if (! (i & 15))
-        printf("%02x:", i);
-          printf(" %02x", get_conf_byte(d, i));
-          if ((i & 15) == 15)
-        putchar('\n');
-        
+        if (! (i & 15))
+      printf("%02x:", i);
+  
           switch(i)
         {
-            case PCI_LOOKUP_VENDOR:
-                printf(" \n\n VENDOR \n\n");
-        }
-    }
+          case PCI_VENDOR_ID:
+            printf("\tVendor ID:\t");
+            break;		
+          case PCI_DEVICE_ID:
+            printf("\n\tDevice ID:\t");
+            break;		
+          case PCI_COMMAND:
+            printf("\n\tCommand:\t");
+            break;	
+          case PCI_STATUS:
+            printf("\n\tStatus:\t\t");
+            break;	
+          case PCI_REVISION_ID:
+            printf("\n\tRevision ID:\t");
+            break;         
+          case PCI_CLASS_PROG:
+            printf("\n\tClass Prog IF:\t");
+            break;          
+          case PCI_CLASS_DEVICE:
+            printf("\n\tClass Device:\t");
+            break;        
+          case PCI_CACHE_LINE_SIZE:
+            printf("\n\tCache Line Size:");
+            break;	
+          case PCI_LATENCY_TIMER:
+            printf("\n\tLatency Timer:\t");
+            break;	
+          case PCI_HEADER_TYPE:
+            printf("\n\tHeader Type:\t");
+            break;		
+          case PCI_BIST_CODE_MASK:
+            printf("\n\tBIST Code Mask: ");
+            break;	
+          case PCI_BIST_START:
+            printf("\n\tBIST Start:\t");
+            break;		
+          case PCI_BIST_CAPABLE:
+            printf("\n\tBIST Capable:\t");
+            break;	
+          case PCI_BASE_ADDRESS_0:
+            printf("\tBAR 0:\t\t");
+            break;	
+          case PCI_BASE_ADDRESS_1:
+            printf("\n\tBAR 1:\t\t");
+            break;	
+          case PCI_BASE_ADDRESS_2:
+            printf("\n\tBAR 2:\t\t");
+            break;	
+          case PCI_BASE_ADDRESS_3:
+            printf("\n\tBAR 3:\t\t");
+            break;	
+          case PCI_BASE_ADDRESS_4:
+            printf("\tBAR 4:\t\t");
+            break;	
+          case PCI_BASE_ADDRESS_5:
+            printf("\n\tBAR 5:\t\t");
+            break;	
+          case PCI_CARDBUS_CIS:
+            printf("\n\tCardbus CIS:\t");
+            break;		
+          case PCI_SUBSYSTEM_VENDOR_ID:
+            printf("\n\tSubsys Vendor:\t");
+            break;	
+          case PCI_SUBSYSTEM_ID:
+            printf("\n\tSubsystem ID:\t");
+            break;	
+          case PCI_ROM_ADDRESS:
+            printf("\tExpan ROM BAR:\t");
+            break;		
+          case PCI_CAPABILITY_LIST:
+            printf("\n\tCapability Ptr:\t");
+            break;
+          case PCI_CAPABILITY_LIST+1:
+            printf("\n\tReserved:\t");
+            break;
+          case PCI_INTERRUPT_LINE:
+            printf("\n\tInterrupt Line:\t");
+            break;	
+          case PCI_INTERRUPT_PIN:
+            printf("\n\tInterrupt Pin:\t");
+            break;	
+          case PCI_MIN_GNT:
+            printf("\n\tMin Gnt:\t");
+            break;		
+          case PCI_MAX_LAT:
+            printf("\n\tMax Lat:\t");
+            break;		
 #if 0
-PCI_LOOKUP_DEVICE 
-PCI_LOOKUP_CLASS 
-PCI_LOOKUP_SUBSYSTEM 
-PCI_LOOKUP_PROGIF 
-PCI_LOOKUP_NUMERIC 
-PCI_LOOKUP_NO_NUMBERS 
-PCI_LOOKUP_MIXED 
-PCI_LOOKUP_NETWORK 
-PCI_LOOKUP_SKIP_LOCAL 
-PCI_LOOKUP_CACHE 
-PCI_LOOKUP_REFRESH_CACHE 
-PCI_LOOKUP_NO_HWDB 
-
+          case PCI_PRIMARY_BUS:
+            printf("\n\tReserved:\t");
+            break;		
+          case PCI_SECONDARY_BUS:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_SUBORDINATE_BUS:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_SEC_LATENCY_TIMER:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_IO_BASE:
+            printf("\n\tReserved:\t");
+            break;		
+          case PCI_IO_LIMIT:
+            printf("\n\tReserved:\t");
+            break;		
+          case PCI_SEC_STATUS:
+            printf("\n\tReserved:\t");
+            break;		
+          case PCI_MEMORY_BASE:
+            printf("\n\tReserved:\t");
+            break;		
+          case PCI_MEMORY_LIMIT:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_PREF_MEMORY_BASE:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_PREF_MEMORY_LIMIT:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_PREF_BASE_UPPER32:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_PREF_LIMIT_UPPER32:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_IO_BASE_UPPER16:
+            printf("\n\tReserved:\t");
+            break;	
+          case PCI_IO_LIMIT_UPPER16:
+            printf("\n\tReserved:\t");
+            break;
 #endif
-
-
-
-
-
+        }
+          
+        printf(" %02x", get_conf_byte(d, i));
+        if ((i & 15) == 15)
+      putchar('\n');
+        
+    }
 }
 
 static void

--- a/lspci.c
+++ b/lspci.c
@@ -971,7 +971,7 @@ print_header_type_0(int i, int *field_len_ptr)
       field_len--;
       field_len = *field_len_ptr;
       break;
-    }
+  }
   
   *field_len_ptr = field_len;
 }
@@ -1079,19 +1079,130 @@ print_header_type_1(int i, int *field_len_ptr)
       field_len--;
       field_len = *field_len_ptr;
       break;
-    }
+  }
   *field_len_ptr = field_len;
 }
 
-#if 0
 static int
-print_header_type_2(int i)
+print_header_type_2(int i, int *field_len_ptr)
 {
   int field_len=0;
 
+  switch(i)
+  {
+    case PCI_BASE_ADDRESS_0:
+      printf("\tCardbus Base Address:\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_CAPABILITY_LIST:
+      printf("\n\tOffset capabilities:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_CAPABILITY_LIST + 1:
+      printf("\n\tReserved:\t\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_SEC_STATUS:
+      printf("\n\tSecondary status:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_PRIMARY_BUS:
+      printf("\n\tBus number:\t\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_CARD_BUS	:
+      printf("\n\tCard Bus number:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_SUBORDINATE_BUS:
+      printf("\n\tSubordinate Bus number:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_LATENCY_TIMER:
+      printf("\n\tCard Bus latency timer:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_MEMORY_BASE_0:
+      printf("\n\tMemory Base Address 0:\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_MEMORY_LIMIT_0:
+      printf("\tMemory Limit 0:\t\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_MEMORY_BASE_1:
+      printf("\n\tMemory Base Address 1:\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_MEMORY_LIMIT_1:
+      printf("\n\tMemory Limit 1:\t\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_IO_BASE_0:
+      printf("\n\tI/O Base Address 0:\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_IO_BASE_0_HI:
+      printf("\n\tI/O Base 0 High:\t");
+      field_len = sizeof(u32);
+      break;
+    case PCI_CB_IO_LIMIT_0:
+      printf("\tI/O Limit 0:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_IO_LIMIT_0_HI:
+      printf("\n\tI/O Limit 0 Hi:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_IO_BASE_1:
+      printf("\n\tI/O Base 1:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_IO_BASE_1_HI:
+      printf("\n\tI/O Base 1 Hi:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_IO_LIMIT_1:
+      printf("\n\tI/O Limit 1:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_IO_LIMIT_1_HI:
+      printf("\n\tI/O Limit 1 Hi:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_INTERRUPT_LINE:
+      printf("\n\tInterrupt Line:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_INTERRUPT_PIN:
+      printf("\n\tInterrupt PIN:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CB_BRIDGE_CONTROL:
+      printf("\n\tBridge Control:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_SUBSYSTEM_VENDOR_ID:
+      printf("\n\tSubsystem Vendor:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_SUBSYSTEM_ID:
+      printf("\n\tSubsystem Device:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CB_LEGACY_MODE_BASE:
+      printf("\n\tLegacy Base Address:\t");
+      field_len = sizeof(u32);
+      break;
+    default:
+      field_len--;
+      field_len = *field_len_ptr;
+      break;
+  }
+  *field_len_ptr = field_len;
+
   return field_len;
 }
-#endif
 
 static void
 show_hex_parsed(struct device *d)
@@ -1169,13 +1280,14 @@ show_hex_parsed(struct device *d)
         {
             switch(header_type & 0x0003)
           {
-            case 0:
+            case PCI_HEADER_TYPE_NORMAL:
               print_header_type_0(i, &field_len);
               break;
-            case 1:
+            case PCI_HEADER_TYPE_BRIDGE:
               print_header_type_1(i, &field_len);
               break;
-            case 2:
+            case PCI_HEADER_TYPE_CARDBUS:
+              print_header_type_2(i, &field_len);
               break;
             default:
               break;

--- a/lspci.c
+++ b/lspci.c
@@ -227,8 +227,6 @@ compare_them(const void *A, const void *B)
   return 0;
 }
 
-
-
 static void
 sort_them(void)
 {
@@ -902,7 +900,7 @@ static void
 show_hex_parsed(struct device *d)
 {
   unsigned int i, cnt;
-  int dbgidx = 0;
+  int field_len=0;
 
   cnt = d->config_cached;
   if (opt_hex_parsed >= 3 && config_fetch(d, cnt, 256-cnt))
@@ -921,90 +919,111 @@ show_hex_parsed(struct device *d)
         {
           case PCI_VENDOR_ID:
             printf("\tVendor ID:\t");
+            field_len = sizeof(d->dev->vendor_id);
             break;		
           case PCI_DEVICE_ID:
             printf("\n\tDevice ID:\t");
+            field_len = sizeof(d->dev->device_id);
             break;		
           case PCI_COMMAND:
             printf("\n\tCommand:\t");
+            field_len = sizeof(word);
             break;	
           case PCI_STATUS:
             printf("\n\tStatus:\t\t");
+            field_len = sizeof(word);
             break;	
           case PCI_REVISION_ID:
             printf("\n\tRevision ID:\t");
+            field_len = sizeof(byte);
             break;         
           case PCI_CLASS_PROG:
             printf("\n\tClass Prog IF:\t");
+            field_len = sizeof(byte);
             break;          
           case PCI_CLASS_DEVICE:
             printf("\n\tClass Device:\t");
+            field_len = sizeof(byte);
             break;        
           case PCI_CACHE_LINE_SIZE:
             printf("\n\tCache Line Size:");
+            field_len = sizeof(byte);
             break;	
           case PCI_LATENCY_TIMER:
             printf("\n\tLatency Timer:\t");
+            field_len = sizeof(byte);
             break;	
           case PCI_HEADER_TYPE:
             printf("\n\tHeader Type:\t");
+            field_len = sizeof(byte);
             break;		
-          case PCI_BIST_CODE_MASK:
-            printf("\n\tBIST Code Mask: ");
-            break;	
-          case PCI_BIST_START:
-            printf("\n\tBIST Start:\t");
-            break;		
-          case PCI_BIST_CAPABLE:
-            printf("\n\tBIST Capable:\t");
-            break;	
+          case PCI_BIST:
+            printf("\n\tBIST:\t\t");
+            field_len = sizeof(byte);
+            break;
           case PCI_BASE_ADDRESS_0:
             printf("\tBAR 0:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_BASE_ADDRESS_1:
             printf("\n\tBAR 1:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_BASE_ADDRESS_2:
             printf("\n\tBAR 2:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_BASE_ADDRESS_3:
             printf("\n\tBAR 3:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_BASE_ADDRESS_4:
             printf("\tBAR 4:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_BASE_ADDRESS_5:
             printf("\n\tBAR 5:\t\t");
+            field_len = sizeof(u32);
             break;	
           case PCI_CARDBUS_CIS:
             printf("\n\tCardbus CIS:\t");
+            field_len = sizeof(u32);
             break;		
           case PCI_SUBSYSTEM_VENDOR_ID:
             printf("\n\tSubsys Vendor:\t");
+            field_len = sizeof(word);
             break;	
           case PCI_SUBSYSTEM_ID:
             printf("\n\tSubsystem ID:\t");
+            field_len = sizeof(word);
             break;	
           case PCI_ROM_ADDRESS:
             printf("\tExpan ROM BAR:\t");
+            field_len = sizeof(u32);
             break;		
           case PCI_CAPABILITY_LIST:
             printf("\n\tCapability Ptr:\t");
+            field_len = sizeof(byte);
             break;
           case PCI_CAPABILITY_LIST+1:
             printf("\n\tReserved:\t");
+            field_len = sizeof(u32)+sizeof(word)+sizeof(byte);
             break;
           case PCI_INTERRUPT_LINE:
             printf("\n\tInterrupt Line:\t");
+            field_len = sizeof(byte);
             break;	
           case PCI_INTERRUPT_PIN:
             printf("\n\tInterrupt Pin:\t");
+            field_len = sizeof(byte);
             break;	
           case PCI_MIN_GNT:
-            printf("\n\tMin Gnt:\t");
+            printf("\n\tMin Grant:\t");
+            field_len = sizeof(byte);
             break;		
           case PCI_MAX_LAT:
-            printf("\n\tMax Lat:\t");
+            printf("\n\tMax Latency:\t");
+            field_len = sizeof(byte);
             break;		
 #if 0
           case PCI_PRIMARY_BUS:
@@ -1053,9 +1072,11 @@ show_hex_parsed(struct device *d)
             printf("\n\tReserved:\t");
             break;
 #endif
+          default:
+            field_len--;
+            break;
         }
-          
-        printf(" %02x", get_conf_byte(d, i));
+        printf(" %02x", get_conf_byte(d, i+(--field_len)));
         if ((i & 15) == 15)
       putchar('\n');
         
@@ -1192,8 +1213,6 @@ main(int argc, char **argv)
   pacc = pci_alloc();
   pacc->error = die;
   pci_filter_init(pacc, &filter);
-
-  printf("\n\n MODIFIED lspci\n");
 
   while ((i = getopt(argc, argv, options)) != -1)
     switch (i)

--- a/lspci.c
+++ b/lspci.c
@@ -897,10 +897,207 @@ show_hex_dump(struct device *d)
 }
 
 static void
+print_header_type_0(int i, int *field_len_ptr)
+{
+  int field_len=0;
+  
+  switch(i)
+  {
+    case PCI_BASE_ADDRESS_0:
+      printf("\tBAR 0:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_1:
+      printf("\n\tBAR 1:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_2:
+      printf("\n\tBAR 2:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_3:
+      printf("\n\tBAR 3:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_4:
+      printf("\tBAR 4:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_5:
+      printf("\n\tBAR 5:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_CARDBUS_CIS:
+      printf("\n\tCardbus CIS:\t");
+      field_len = sizeof(u32);
+      break;		
+    case PCI_SUBSYSTEM_VENDOR_ID:
+      printf("\n\tSubsys Vendor:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_SUBSYSTEM_ID:
+      printf("\n\tSubsystem ID:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_ROM_ADDRESS:
+      printf("\tExpan ROM BAR:\t");
+      field_len = sizeof(u32);
+      break;		
+    case PCI_CAPABILITY_LIST:
+      printf("\n\tCapability Ptr:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CAPABILITY_LIST+1:
+      printf("\n\tReserved:\t");
+      field_len = sizeof(u32)+sizeof(word)+sizeof(byte);
+      break;
+    case PCI_INTERRUPT_LINE:
+      printf("\n\tInterrupt Line:\t");
+      field_len = sizeof(byte);
+      break;	
+    case PCI_INTERRUPT_PIN:
+      printf("\n\tInterrupt Pin:\t");
+      field_len = sizeof(byte);
+      break;	
+    case PCI_MIN_GNT:
+      printf("\n\tMin Grant:\t");
+      field_len = sizeof(byte);
+      break;		
+    case PCI_MAX_LAT:
+      printf("\n\tMax Latency:\t");
+      field_len = sizeof(byte);
+      break;		
+    default:
+      field_len--;
+      field_len = *field_len_ptr;
+      break;
+    }
+  
+  *field_len_ptr = field_len;
+}
+
+static void
+print_header_type_1(int i, int *field_len_ptr)
+{
+  int field_len=0;
+
+  switch(i)
+  {  
+    case PCI_BASE_ADDRESS_0:
+      printf("\tBAR 0:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_BASE_ADDRESS_1:
+      printf("\n\tBAR 1:\t\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_PRIMARY_BUS:
+      printf("\n\tPrimary Bus:\t");
+      field_len = sizeof(byte);
+      break;		
+    case PCI_SECONDARY_BUS:
+      printf("\n\tSecondary Bus:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_SUBORDINATE_BUS:
+      printf("\n\tSubordinate Bus:");
+      field_len = sizeof(byte);
+      break;
+    case PCI_SEC_LATENCY_TIMER:
+      printf("\n\tSec Latency Tmr:");
+      field_len = sizeof(byte);
+      break;
+    case PCI_IO_BASE:
+      printf("\n\tI/O Base:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_IO_LIMIT:
+      printf("\n\tI/O Limit:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_SEC_STATUS:
+      printf("\n\tSec Status:\t");
+      field_len = sizeof(word);
+      break;		
+    case PCI_MEMORY_BASE:
+      printf("\tMemory Base:\t");
+      field_len = sizeof(word);
+      break;		
+    case PCI_MEMORY_LIMIT:
+      printf("\n\tMemory Limit:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_PREF_MEMORY_BASE:
+      printf("\n\tPref Mem Base:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_PREF_MEMORY_LIMIT:
+      printf("\n\tPref Mem Limit:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_PREF_BASE_UPPER32:
+      printf("\n\tPref Base Up32:\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_PREF_LIMIT_UPPER32:
+      printf("\n\tPref Lim Up32:\t");
+      field_len = sizeof(u32);
+      break;	
+    case PCI_IO_BASE_UPPER16:
+      printf("\tI/O Base Up16:\t");
+      field_len = sizeof(word);
+      break;	
+    case PCI_IO_LIMIT_UPPER16:
+      printf("\n\tI/O Lim Up16:\t");
+      field_len = sizeof(word);
+      break;
+    case PCI_CAPABILITY_LIST:
+      printf("\n\tCapability Ptr:\t");
+      field_len = sizeof(byte);
+      break;
+    case PCI_CAPABILITY_LIST+1:
+      printf("\n\tReserved:\t");
+      field_len = sizeof(word)+sizeof(byte);
+      break;
+    case PCI_ROM_ADDRESS1:
+      printf("\n\tExpan ROM BAR:\t");
+      field_len = sizeof(u32);
+      break;		
+    case PCI_INTERRUPT_LINE:
+      printf("\n\tInterrupt Line:\t");
+      field_len = sizeof(byte);
+      break;	
+    case PCI_INTERRUPT_PIN:
+      printf("\n\tInterrupt Pin:\t");
+      field_len = sizeof(byte);
+      break;	
+    case PCI_BRIDGE_CONTROL:
+      printf("\n\tBridge Control:\t");
+      field_len = sizeof(word);
+      break;		
+    default:
+      field_len--;
+      field_len = *field_len_ptr;
+      break;
+    }
+  *field_len_ptr = field_len;
+}
+
+#if 0
+static int
+print_header_type_2(int i)
+{
+  int field_len=0;
+
+  return field_len;
+}
+#endif
+
+static void
 show_hex_parsed(struct device *d)
 {
-  unsigned int i, cnt;
-  int field_len=0;
+  unsigned int i, cnt, header_type = 0;
+  int field_len = 0;
 
   cnt = d->config_cached;
   if (opt_hex_parsed >= 3 && config_fetch(d, cnt, 256-cnt))
@@ -943,7 +1140,7 @@ show_hex_parsed(struct device *d)
             break;          
           case PCI_CLASS_DEVICE:
             printf("\n\tClass Device:\t");
-            field_len = sizeof(byte);
+            field_len = sizeof(word);
             break;        
           case PCI_CACHE_LINE_SIZE:
             printf("\n\tCache Line Size:");
@@ -956,126 +1153,35 @@ show_hex_parsed(struct device *d)
           case PCI_HEADER_TYPE:
             printf("\n\tHeader Type:\t");
             field_len = sizeof(byte);
+            /* if 0x1000 */
             break;		
           case PCI_BIST:
-            printf("\n\tBIST:\t\t");
+            printf("\n\tBIST:\t\t"); 
+            header_type = get_conf_byte(d, i+field_len-1);
             field_len = sizeof(byte);
             break;
-          case PCI_BASE_ADDRESS_0:
-            printf("\tBAR 0:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_BASE_ADDRESS_1:
-            printf("\n\tBAR 1:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_BASE_ADDRESS_2:
-            printf("\n\tBAR 2:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_BASE_ADDRESS_3:
-            printf("\n\tBAR 3:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_BASE_ADDRESS_4:
-            printf("\tBAR 4:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_BASE_ADDRESS_5:
-            printf("\n\tBAR 5:\t\t");
-            field_len = sizeof(u32);
-            break;	
-          case PCI_CARDBUS_CIS:
-            printf("\n\tCardbus CIS:\t");
-            field_len = sizeof(u32);
-            break;		
-          case PCI_SUBSYSTEM_VENDOR_ID:
-            printf("\n\tSubsys Vendor:\t");
-            field_len = sizeof(word);
-            break;	
-          case PCI_SUBSYSTEM_ID:
-            printf("\n\tSubsystem ID:\t");
-            field_len = sizeof(word);
-            break;	
-          case PCI_ROM_ADDRESS:
-            printf("\tExpan ROM BAR:\t");
-            field_len = sizeof(u32);
-            break;		
-          case PCI_CAPABILITY_LIST:
-            printf("\n\tCapability Ptr:\t");
-            field_len = sizeof(byte);
-            break;
-          case PCI_CAPABILITY_LIST+1:
-            printf("\n\tReserved:\t");
-            field_len = sizeof(u32)+sizeof(word)+sizeof(byte);
-            break;
-          case PCI_INTERRUPT_LINE:
-            printf("\n\tInterrupt Line:\t");
-            field_len = sizeof(byte);
-            break;	
-          case PCI_INTERRUPT_PIN:
-            printf("\n\tInterrupt Pin:\t");
-            field_len = sizeof(byte);
-            break;	
-          case PCI_MIN_GNT:
-            printf("\n\tMin Grant:\t");
-            field_len = sizeof(byte);
-            break;		
-          case PCI_MAX_LAT:
-            printf("\n\tMax Latency:\t");
-            field_len = sizeof(byte);
-            break;		
-#if 0
-          case PCI_PRIMARY_BUS:
-            printf("\n\tReserved:\t");
-            break;		
-          case PCI_SECONDARY_BUS:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_SUBORDINATE_BUS:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_SEC_LATENCY_TIMER:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_IO_BASE:
-            printf("\n\tReserved:\t");
-            break;		
-          case PCI_IO_LIMIT:
-            printf("\n\tReserved:\t");
-            break;		
-          case PCI_SEC_STATUS:
-            printf("\n\tReserved:\t");
-            break;		
-          case PCI_MEMORY_BASE:
-            printf("\n\tReserved:\t");
-            break;		
-          case PCI_MEMORY_LIMIT:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_PREF_MEMORY_BASE:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_PREF_MEMORY_LIMIT:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_PREF_BASE_UPPER32:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_PREF_LIMIT_UPPER32:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_IO_BASE_UPPER16:
-            printf("\n\tReserved:\t");
-            break;	
-          case PCI_IO_LIMIT_UPPER16:
-            printf("\n\tReserved:\t");
-            break;
-#endif
           default:
             field_len--;
             break;
         }
+
+          if(i > PCI_BIST)
+        {
+            switch(header_type & 0x0003)
+          {
+            case 0:
+              print_header_type_0(i, &field_len);
+              break;
+            case 1:
+              print_header_type_1(i, &field_len);
+              break;
+            case 2:
+              break;
+            default:
+              break;
+          }
+        }
+
         printf(" %02x", get_conf_byte(d, i+(--field_len)));
         if ((i & 15) == 15)
       putchar('\n');


### PR DESCRIPTION
New option -X added: 

    lspci -X

Based on -x option, but parses the hexadecimal dump following the PCIe Config Types standards.
This is intended for PCI development or board bring-up purposes.