### PR TITLE
lspci: Show information also for devices with unknown header type

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -1403,4 +1403,10 @@
 
 /* I/O resource flags, compatible with <include/linux/ioport.h> */
 
+#define PCI_IORESOURCE_TYPE_BITS	0x00001f00
+#define PCI_IORESOURCE_IO		0x00000100
+#define PCI_IORESOURCE_MEM		0x00000200
+#define PCI_IORESOURCE_PREFETCH		0x00002000
+#define PCI_IORESOURCE_MEM_64		0x00100000
+#define PCI_IORESOURCE_IO_16BIT_ADDR	(1<<0)
 #define PCI_IORESOURCE_PCI_EA_BEI	(1<<5)


### PR DESCRIPTION
lspci sees header type with 0x7f value in case config space is not
accessible. It may be because of permission issues or missing backend
(e.g. on Windows) or because device itself does not respond to config
cycles and config space is inaccessible.

Inaccessible config space is common scenario for switchable PCIe GPU
cards. Some Nvidia and also some AMD cards when sleep then lspci sees
all-ones in their config space. But kernel has registered those cards and
some of their properties are cached ans available via sysfs or procfs (from
time when card was awake).

Currently lspci shows error message "Unknown header type 7f" and does not
parse any value neither from config space nor from sysfs backend.

So try to show at least information which kernel provided into libpci
struct pci_dev.

Set unknown values to zeros (instead of all-ones which are returned from
config space) and add a new function show_htype_unknown() for showing
additional information in case header type is unknown.

This change will also help new windows backend which has only emulated
config space and therefore valid data only in struct pci_dev.