### PR TITLE
Various I/O port fixes for win32 code

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -153,6 +153,7 @@ case $sys in
 		# So always set -lcfgmgr32 as a first library parameter which
 		# instruct linker to prefer symbols from cfgmgr32.dll.
 		echo >>$m 'WITH_LIBS+=-lcfgmgr32'
+		case $cpu in i?86|x86_64)
 		echo_n " i386-ports"
 		echo >>$c '#define PCI_HAVE_PM_INTEL_CONF'
 		if [ "$sys" = "cygwin" ] ; then
@@ -162,6 +163,7 @@ case $sys in
 			# advapi32 is windows system library and used only by lib/i386-io-windows.h
 			echo >>$m 'WITH_LIBS+=-ladvapi32'
 		fi
+		;; esac
 		EXEEXT=.exe
 		;;
 	beos|haiku)

--- a/lib/i386-io-windows.h
+++ b/lib/i386-io-windows.h
@@ -35,11 +35,11 @@
 #define _inp(x) __inbyte(x)
 #define _inpw(x) __inword(x)
 #define _inpd(x) __indword(x)
-#elif defined(__CRTDLL__)
+#elif defined(__CRTDLL__) || (defined(__MSVCRT_VERSION__) && __MSVCRT_VERSION__ < 0x400)
 /*
- * Old 32-bit CRTDLL library does not provide I/O port functions. As this
- * library exists only in 32-bit mode variant, implement I/O port functions
- * via 32-bit inline assembly.
+ * Old 32-bit CRTDLL library and pre-4.00 MSVCRT library do not provide I/O
+ * port functions. As these libraries exist only in 32-bit mode variant,
+ * implement I/O port functions via 32-bit inline assembly.
  */
 static inline int _outp(unsigned short port, int databyte)
 {

--- a/lib/init.c
+++ b/lib/init.c
@@ -208,7 +208,10 @@ pci_init_name_list_path(struct pci_access *a)
       len = GetModuleFileNameA(NULL, path, MAX_PATH+1);
       sep = (len > 0) ? strrchr(path, '\\') : NULL;
       if (len == 0 || len == MAX_PATH+1 || !sep || MAX_PATH-(size_t)(sep+1-path) < sizeof(PCI_IDS))
-        free(path);
+        {
+          free(path);
+          pci_set_name_list_path(a, PCI_IDS, 0);
+        }
       else
         {
           memcpy(sep+1, PCI_IDS, sizeof(PCI_IDS));


### PR DESCRIPTION
* libpci: Compile windows i386-ports only for x86 CPU
* libpci: Always call pci_set_name_list_path() in pci_init_name_list_path()
* libpci: i386-io-windows.h: Fix MinGW build with pre-4.00 MSVCRT runtime library
* libpci: i386-io-windows.h: Fix error handling for GetProcessImageFileNameW() and GetModuleFileNameExW()