### PR TITLE
lib: Fix PCI_HT_SEC_CMD_DN

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -537,7 +537,7 @@
 #define PCI_HT_SEC_CMD		2	/* Command Register */
 #define  PCI_HT_SEC_CMD_WR	0x0001	/* Warm Reset */
 #define  PCI_HT_SEC_CMD_DE	0x0002	/* Double-Ended */
-#define  PCI_HT_SEC_CMD_DN	0x0076	/* Device Number */
+#define  PCI_HT_SEC_CMD_DN	0x007c	/* Device Number */
 #define  PCI_HT_SEC_CMD_CS	0x0080	/* Chain Side */
 #define  PCI_HT_SEC_CMD_HH	0x0100	/* Host Hide */
 #define  PCI_HT_SEC_CMD_AS	0x0400	/* Act as Slave */


### PR DESCRIPTION
`HyperTransport / Host or Secondary Interface / Command Register / Device Number` mask should be 0b1111100 (0x007c), not 0b1110110 (0x0076).
![Screenshot from 2022-05-20 17-37-40](https://user-images.githubusercontent.com/3964031/169553813-5eed50b0-6a30-4f01-a81d-97628d79b625.png)
