### PR TITLE
lib: Fix PCI_L1PM_SUBSTAT_CAP_L1PM_SUPP

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -537,7 +537,7 @@
 #define PCI_HT_SEC_CMD		2	/* Command Register */
 #define  PCI_HT_SEC_CMD_WR	0x0001	/* Warm Reset */
 #define  PCI_HT_SEC_CMD_DE	0x0002	/* Double-Ended */
-#define  PCI_HT_SEC_CMD_DN	0x0076	/* Device Number */
+#define  PCI_HT_SEC_CMD_DN	0x007c	/* Device Number */
 #define  PCI_HT_SEC_CMD_CS	0x0080	/* Chain Side */
 #define  PCI_HT_SEC_CMD_HH	0x0100	/* Host Hide */
 #define  PCI_HT_SEC_CMD_AS	0x0400	/* Act as Slave */

--- a/lib/header.h
+++ b/lib/header.h
@@ -1248,7 +1248,7 @@
 #define  PCI_L1PM_SUBSTAT_CAP_PM_L11	0x2	/* PCI-PM L1.1 Supported */
 #define  PCI_L1PM_SUBSTAT_CAP_ASPM_L12	0x4	/* ASPM L1.2 Supported */
 #define  PCI_L1PM_SUBSTAT_CAP_ASPM_L11	0x8	/* ASPM L1.1 Supported */
-#define  PCI_L1PM_SUBSTAT_CAP_L1PM_SUPP	0x16	/* L1 PM Substates supported */
+#define  PCI_L1PM_SUBSTAT_CAP_L1PM_SUPP	0x10	/* L1 PM Substates supported */
 #define PCI_L1PM_SUBSTAT_CTL1	0x8	/* L1 PM Substate Control 1 */
 #define  PCI_L1PM_SUBSTAT_CTL1_PM_L12	0x1	/* PCI-PM L1.2 Enable */
 #define  PCI_L1PM_SUBSTAT_CTL1_PM_L11	0x2	/* PCI-PM L1.1 Enable */


### PR DESCRIPTION
Hi!
The mask should be 0b10000, not 0b10110
![Screenshot from 2022-05-30 18-27-20](https://user-images.githubusercontent.com/3964031/171023504-0d0da794-e1c4-4305-b12a-58b38b0da330.png)
