### PR TITLE
lib/configure: drop usage of which

### DIFF
--- a/lib/configure
+++ b/lib/configure
@@ -268,7 +268,7 @@ if [ "$sys" = linux ] ; then
 	if [ "$HWDB" = yes -o "$HWDB" = no ] ; then
 		echo "$HWDB (set manually)"
 	else
-		if `command -v pkg-config >/dev/null && pkg-config --atleast-version=196 libudev` ; then
+		if `command -v $PKG_CONFIG >/dev/null && $PKG_CONFIG --atleast-version=196 libudev` ; then
 			HWDB=yes
 		else
 			HWDB=no

--- a/lib/configure
+++ b/lib/configure
@@ -238,7 +238,7 @@ if [ "$sys" = linux ] ; then
 		PKG_CONFIG=pkg-config
 	fi
 	if [ "$LIBKMOD" != no ] ; then
-		if ! which $PKG_CONFIG >/dev/null ; then
+		if ! command -v $PKG_CONFIG >/dev/null ; then
 			echo_n "($PKG_CONFIG not found) "
 		elif $PKG_CONFIG libkmod ; then
 			LIBKMOD_DETECTED=1
@@ -268,7 +268,7 @@ if [ "$sys" = linux ] ; then
 	if [ "$HWDB" = yes -o "$HWDB" = no ] ; then
 		echo "$HWDB (set manually)"
 	else
-		if `which pkg-config >/dev/null && pkg-config --atleast-version=196 libudev` ; then
+		if `command -v pkg-config >/dev/null && pkg-config --atleast-version=196 libudev` ; then
 			HWDB=yes
 		else
 			HWDB=no


### PR DESCRIPTION
'which' is not required by POSIX and is an external command which may not be
available, and 'command -v' does the job just fine.

Debian and Gentoo at least are both making efforts to drop which from
their base system package list.

Signed-off-by: Sam James <sam@gentoo.org>