### PR TITLE
libpci: i386-io-windows.h: Do not define __readeflags() for GCC 4.9+

### DIFF
--- a/lib/i386-io-windows.h
+++ b/lib/i386-io-windows.h
@@ -107,16 +107,13 @@ unsigned long _inpd(unsigned short port);
  * function conflicts with some MSVC intrinsic.
  * MSVC supports inline assembly via __asm keyword in 32-bit mode only.
  * GCC version 4.9.0 and higher provides __builtin_ia32_readeflags_uXX()
- * builtin for XX-mode.
+ * builtin for XX-mode. This builtin is also available as __readeflags()
+ * function indirectly via <x86intrin.h> header file.
  */
 #if defined(_MSC_VER) && (_MSC_VER >= 1500 || (_MSC_VER >= 1400 && defined(__BUILDMACHINE__)))
 #pragma intrinsic(__readeflags)
 #elif defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || (__GNUC__ > 4))
-#ifdef __x86_64__
-#define __readeflags() __builtin_ia32_readeflags_u64()
-#else
-#define __readeflags() __builtin_ia32_readeflags_u32()
-#endif
+#include <x86intrin.h>
 #elif defined(_MSC_VER) && defined(_M_IX86)
 static inline unsigned int
 __readeflags(void)


### PR DESCRIPTION
GCC header file <x86intrin.h> defines static inline function __readeflags()
which calls correct __builtin_ia32_readeflags_XX() builtin.

Header file <x86intrin.h> is included by MinGW-w64's <intrin.h> header file
in new versions of MinGW-w64 and <intrin.h> may be included transitionally
by some other header files automatically.

Defining __readeflags() as both macro and static inline function cause
compile errors.

Fix this compile error by not defining __readeflags() macro and instead
include GCC header file <x86intrin.h>.