### PR TITLE
libpci: i386-io-windows.h: Improve ProcessUserModeIOPL error message

### DIFF
--- a/lib/i386-io-windows.h
+++ b/lib/i386-io-windows.h
@@ -1343,7 +1343,8 @@ intel_setup_io(struct pci_access *a)
   /* On NT-based systems issue ProcessUserModeIOPL syscall which changes IOPL to 3. */
   if (!SetProcessUserModeIOPL())
     {
-      a->warning("NT ProcessUserModeIOPL call failed with error: %lu.", (unsigned long int)GetLastError());
+      DWORD error = GetLastError();
+      a->debug("NT ProcessUserModeIOPL call failed: %s.", error == ERROR_INVALID_FUNCTION ? "Not Implemented" : error == ERROR_PRIVILEGE_NOT_HELD ? "Access Denied" : "Operation Failed");
       return 0;
     }
 


### PR DESCRIPTION
Show error message from intel_setup_io() function into debug area instead of error area. This is what other backends do as intel_setup_io() is called during quite detect phase, which may fail.

Also show human readable failure instead of magic code number.