### PR TITLE
cxl: Fix Register Locator DVSEC decoding

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -1127,12 +1127,7 @@
 #define PCI_CXL_PORT_ALT_MEM_LIMIT 0x12
 
 /* PCIe CXL 2.0 Designated Vendor-Specific Capabilities for Register Locator */
-#define PCI_CXL_RL_BASE0_LO 0x0c
-#define PCI_CXL_RL_BASE0_HI 0x10
-#define PCI_CXL_RL_BASE1_LO 0x14
-#define PCI_CXL_RL_BASE1_HI 0x18
-#define PCI_CXL_RL_BASE2_LO 0x1c
-#define PCI_CXL_RL_BASE2_HI 0x20
+#define PCI_CXL_RL_BLOCK1_LO 0x0c
 
 /* Access Control Services */
 #define PCI_ACS_CAP		0x04	/* ACS Capability Register */

--- a/ls-ecaps.c
+++ b/ls-ecaps.c
@@ -812,8 +812,8 @@ dvsec_cxl_register_locator(struct device *d, int where, int len)
 
   for (int i=0; ; i++)
     {
-      int pos = where + 8*i;
-      if (pos + 7 >= len)
+      int pos = where + PCI_CXL_RL_BLOCK1_LO + 8*i;
+      if (pos + 7 >= where + len)
 	break;
 
       u32 lo = get_conf_long(d, pos);
@@ -834,7 +834,7 @@ dvsec_cxl_register_locator(struct device *d, int where, int len)
       else
 	id_name = "<?>";
 
-      printf("\t\tBlock%d: BIR: bar%d, ID: %s, offset: %016" PCI_U64_FMT_X "\n", i, bir, id_name, base);
+      printf("\t\tBlock%d: BIR: bar%d, ID: %s, offset: %016" PCI_U64_FMT_X "\n", i + 1, bir, id_name, base);
     }
 }
 


### PR DESCRIPTION
Fix decoding of register blocks by introducing offset to position calculation (8.1.9 of CXL 3.0 spec) and removed unused defines for Register Locator DVSEC. According to Figure 8-6 (8.1.9 of CXL 3.0 spec), Register Blocks are also indexed starting at 1. 

Signed-off-by: Jaxon Haws <jaxon.haws@amd.com>