### PR TITLE
windows: Put name and version information into lspci/setpci executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,21 @@ example.o: example.c $(PCIINC)
 %$(EXEEXT): %.o
 	$(CC) $(LDFLAGS) $(TARGET_ARCH) $^ $(LDLIBS) -o $@
 
+ifdef PCI_OS_WINDOWS
+comma := ,
+%-rsrc.rc: lib/winrsrc.rc.in
+	sed <$< >$@ -e 's,@PCILIB_VERSION@,$(PCILIB_VERSION),' \
+		-e 's,@PCILIB_VERSION_WINRC@,$(subst .,\$(comma),$(PCILIB_VERSION).0),' \
+		-e 's,@FILENAME@,$(subst -rsrc.rc,$(EXEEXT),$@),' \
+		-e 's,@DESCRIPTION@,$(subst -rsrc.rc,,$@),' \
+		-e 's,@LIBRARY_BUILD@,0,' \
+		-e 's,@DEBUG_BUILD@,$(if $(findstring -g,$(CFLAGS)),1,0),'
+%-rsrc.o: %-rsrc.rc
+	$(WINDRES) --input=$< --output=$@ --input-format=rc --output-format=coff
+lspci$(EXEEXT): lspci-rsrc.o
+setpci$(EXEEXT): setpci-rsrc.o
+endif
+
 %.8 %.7 %.5: %.man
 	M=`echo $(DATE) | sed 's/-01-/-January-/;s/-02-/-February-/;s/-03-/-March-/;s/-04-/-April-/;s/-05-/-May-/;s/-06-/-June-/;s/-07-/-July-/;s/-08-/-August-/;s/-09-/-September-/;s/-10-/-October-/;s/-11-/-November-/;s/-12-/-December-/;s/\(.*\)-\(.*\)-\(.*\)/\3 \2 \1/'` ; sed <$< >$@ "s/@TODAY@/$$M/;s/@VERSION@/pciutils-$(VERSION)/;s#@IDSDIR@#$(IDSDIR)#;s#@PCI_IDS@#$(PCI_IDS)#"
 
@@ -125,7 +140,7 @@ TAGS:
 
 clean:
 	rm -f `find . -name "*~" -o -name "*.[oa]" -o -name "\#*\#" -o -name TAGS -o -name core -o -name "*.orig"`
-	rm -f update-pciids lspci$(EXEEXT) setpci$(EXEEXT) example$(EXEEXT) lib/config.* *.[578] pci.ids.gz lib/*.pc lib/*.so lib/*.so.* lib/*.dll lib/*.def lib/dllrsrc.rc tags
+	rm -f update-pciids lspci$(EXEEXT) setpci$(EXEEXT) example$(EXEEXT) lib/config.* *.[578] pci.ids.gz lib/*.pc lib/*.so lib/*.so.* lib/*.dll lib/*.def lib/dllrsrc.rc *-rsrc.rc tags
 	rm -rf maint/dist
 
 distclean: clean

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -79,10 +79,12 @@ $(PCIIMPDEF): libpci.ver ver2def.pl
 $(PCIIMPLIB): $(PCIIMPDEF)
 	$(DLLTOOL) --input-def $< --output-lib $@
 comma := ,
-dllrsrc.rc: dllrsrc.rc.in
+dllrsrc.rc: winrsrc.rc.in
 	sed <$< >$@ -e 's,@PCILIB_VERSION@,$(PCILIB_VERSION),' \
 		-e 's,@PCILIB_VERSION_WINRC@,$(subst .,\$(comma),$(PCILIB_VERSION).0),' \
-		-e 's,@PCILIB@,$(PCILIB),' \
+		-e 's,@FILENAME@,$(PCILIB),' \
+		-e 's,@DESCRIPTION@,libpci,' \
+		-e 's,@LIBRARY_BUILD@,1,' \
 		-e 's,@DEBUG_BUILD@,$(if $(findstring -g,$(CFLAGS)),1,0),'
 dllrsrc.o: dllrsrc.rc
 	$(WINDRES) --input=$< --output=$@ --input-format=rc --output-format=coff

--- a/lib/winrsrc.rc.in
+++ b/lib/winrsrc.rc.in
@@ -34,6 +34,6 @@ BEGIN
 	END
 	BLOCK "VarFileInfo"
 	BEGIN
-		VALUE "Translation", 0x0409, 0x004B0 /* Default U.S. English language, UNICODE/UTF-16 codepage */
+		VALUE "Translation", 0x0409, 0x04B0 /* Default U.S. English language, UNICODE/UTF-16 codepage */
 	END
 END

--- a/lib/winrsrc.rc.in
+++ b/lib/winrsrc.rc.in
@@ -9,7 +9,11 @@ FILEFLAGS VS_FF_DEBUG
 FILEFLAGS 0
 #endif
 FILEOS VOS_NT_WINDOWS32
+#if @LIBRARY_BUILD@
 FILETYPE VFT_DLL
+#else
+FILETYPE VFT_APP
+#endif
 FILESUBTYPE 0
 BEGIN
 	BLOCK "StringFileInfo"
@@ -20,10 +24,10 @@ BEGIN
 		 */
 		BLOCK "040904B0" /* Default U.S. English language, UNICODE/UTF-16 codepage */
 		BEGIN
-			VALUE "FileDescription", "libpci"
+			VALUE "FileDescription", "@DESCRIPTION@"
 			VALUE "FileVersion", "@PCILIB_VERSION@"
-			VALUE "InternalName", "@PCILIB@"
-			VALUE "OriginalFilename", "@PCILIB@"
+			VALUE "InternalName", "@FILENAME@"
+			VALUE "OriginalFilename", "@FILENAME@"
 			VALUE "ProductName", "pciutils"
 			VALUE "ProductVersion", "@PCILIB_VERSION@"
 		END


### PR DESCRIPTION
Extend existing .in resource template file and generate resource objects also for lspci.exe and setpci.exe executables.