### PR TITLE
libpci: mmio-ports: Add Extended PCIe Intel Type 1 access method

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -93,7 +93,9 @@ static struct pci_methods *pci_methods[PCI_ACCESS_MAX] = {
 #endif
 #ifdef PCI_HAVE_PM_MMIO_CONF
   &pm_mmio_conf1,
+  &pm_mmio_conf1_ext,
 #else
+  NULL,
   NULL,
 #endif
 };
@@ -116,6 +118,7 @@ static int probe_sequence[] = {
   // Low-level methods poking the hardware directly
   PCI_ACCESS_I386_TYPE1,
   PCI_ACCESS_I386_TYPE2,
+  PCI_ACCESS_MMIO_TYPE1_EXT,
   PCI_ACCESS_MMIO_TYPE1,
   -1,
 };

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -134,5 +134,5 @@ void pci_free_caps(struct pci_dev *);
 extern struct pci_methods pm_intel_conf1, pm_intel_conf2, pm_linux_proc,
 	pm_fbsd_device, pm_aix_device, pm_nbsd_libpci, pm_obsd_device,
 	pm_dump, pm_linux_sysfs, pm_darwin, pm_sylixos_device, pm_hurd,
-	pm_mmio_conf1,
+	pm_mmio_conf1, pm_mmio_conf1_ext,
 	pm_win32_cfgmgr32, pm_win32_kldbg, pm_win32_sysdbg;

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -47,6 +47,7 @@ enum pci_access_type {
   PCI_ACCESS_WIN32_KLDBG,		/* Win32 kldbgdrv.sys */
   PCI_ACCESS_WIN32_SYSDBG,		/* Win32 NT SysDbg */
   PCI_ACCESS_MMIO_TYPE1,		/* MMIO ports, type 1 */
+  PCI_ACCESS_MMIO_TYPE1_EXT,		/* MMIO ports, type 1 extended */
   PCI_ACCESS_MAX
 };
 

--- a/pcilib.man
+++ b/pcilib.man
@@ -47,6 +47,13 @@ needs to be properly configured via the
 .B mmio-conf1.addrs
 parameter.
 .TP
+.B mmio-conf1-ext
+Direct hardware access via Extended PCIe Intel configuration mechanism 1 via memory-mapped I/O.
+Mostly used on non-i386 platforms. Requires root privileges. Warning: This method
+needs to be properly configured via the
+.B mmio-conf1-ext.addrs
+parameter.
+.TP
 .B fbsd-device
 The
 .B /dev/pci
@@ -152,6 +159,12 @@ Physical addresses of memory-mapped I/O ports for Intel configuration mechanism 
 CF8 (address) and CFC (data) I/O port addresses are separated by slash and
 multiple addresses for different PCI domains are separated by commas.
 Format: 0xaddr1/0xdata1,0xaddr2/0xdata2,...
+.TP
+.B mmio-conf1-ext.addrs
+Physical addresses of memory-mapped I/O ports for Extended PCIe Intel configuration mechanism 1.
+It has same format as
+.B mmio-conf1.addrs
+parameter.
 
 .SS Parameters for resolving of ID's via DNS
 .TP


### PR DESCRIPTION
Extended method allows to access all PCIe registers, including extended registers starting at 0x100 offset. This method uses 4 reserved buts above bus bits for PCIe registers. On ARM platforms it is very common for PCIe controllers. Like standard method, it needs to be properly configured.