### PR TITLE
libpci: win32-cfgmgr32: Add support for accessing config space via other backend

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -81,6 +81,7 @@ int pci_emulated_read(struct pci_dev *d, int pos, byte *buf, int len);
 void *pci_malloc(struct pci_access *, int);
 void pci_mfree(void *);
 char *pci_strdup(struct pci_access *a, const char *s);
+void pci_init_internal(struct pci_access *a, int throw_errors, int skip_method);
 
 void pci_init_v30(struct pci_access *a) VERSIONED_ABI;
 void pci_init_v35(struct pci_access *a) VERSIONED_ABI;

--- a/pcilib.man
+++ b/pcilib.man
@@ -86,8 +86,12 @@ Device listing on Windows systems using the Windows Configuration Manager
 via cfgmgr32.dll system library. This method does not require any special
 Administrator rights or privileges. Configuration Manager provides only basic
 information about devices, assigned resources and device tree structure. There
-is no access to the PCI configuration space but libpci provides read-only
-virtual emulation based on information from Configuration Manager. Starting
+is no access to the PCI configuration space but libpci either tries to use
+other access method to access configuration space or it provides read-only
+virtual emulation based on information from Configuration Manager. Other
+access method can be chosen by the
+.B win32.cfgmethod
+parameter. By default the first working one is selected (if any). Starting
 with Windows 8 (NT 6.2) it is not possible to retrieve resources from 32-bit
 application or library on 64-bit system.
 .TP
@@ -165,6 +169,15 @@ Physical addresses of memory-mapped I/O ports for Extended PCIe Intel configurat
 It has same format as
 .B mmio-conf1.addrs
 parameter.
+.TP
+.B win32.cfgmethod
+Config space access method for win32-cfgmgr32 on Windows systems. Value
+.I auto
+or emtpy string probe and choose the first access method which supports access
+to the config space access on Windows. Value
+.I win32-cfgmgr32
+only builds read-only virtual emulated config space with information from the
+Configuration Manager.
 
 .SS Parameters for resolving of ID's via DNS
 .TP


### PR DESCRIPTION
Extend win32-cfgmgr32 backend and add a new option win32.cfgmethod for specifying other backend for accessing PCI config space. There are more config space access methods available on Windows and each is working only sometimes (either requires special privileges or special setup).

So by default try to choose the first working one via order defined in pci probe_sequence[] array. If none is available then emulate PCI config space like before this change.

Function pci_init_v35() is extended and renamed to pci_init_internal() to optionally do not throw errors and allow to specify one access method which will be skipped in AUTO mode. This is used to prevent choosing win32-cfgmgr32 as config space access method for win32-cfgmgr32.