### PR TITLE
libpci: mmio-ports: Fix support for 64-bit non-LLP64 systems

### DIFF
--- a/lib/mmio-ports.c
+++ b/lib/mmio-ports.c
@@ -124,9 +124,9 @@ writew(unsigned short value, volatile void *addr)
 }
 
 static void
-writel(unsigned long value, volatile void *addr)
+writel(u32 value, volatile void *addr)
 {
-  *(volatile unsigned long *)addr = value;
+  *(volatile u32 *)addr = value;
 }
 
 static unsigned char
@@ -141,10 +141,10 @@ readw(volatile void *addr)
   return *(volatile unsigned short *)addr;
 }
 
-static unsigned long
+static u32
 readl(volatile void *addr)
 {
-  return *(volatile unsigned long *)addr;
+  return *(volatile u32 *)addr;
 }
 
 static int


### PR DESCRIPTION
On 64-bit non-LLP64 systems is type long 64-bit. On 32-bit and 64-bit LLP64 systems is type long only 32-bit. But readl() and writel() functions works with 32-bit PCI word. Fix it for non-LLP64 systems by using type u32.