### PR TITLE
Makefile: change STRIP to '--strip-program' when cross-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,11 @@ PKGCFDIR=$(LIBDIR)/pkgconfig
 # Commands
 INSTALL=install
 DIRINSTALL=install -d
-STRIP=-s
 ifdef CROSS_COMPILE
+STRIP=--strip-program $(CROSS_COMPILE)-strip
 CC=$(CROSS_COMPILE)gcc
 else
+STRIP=-s
 CC=cc
 endif
 AR=$(CROSS_COMPILE)ar


### PR DESCRIPTION
When cross-compile, we should use specific strip instead of default /usr/bin/strip.

reference:https://man7.org/linux/man-pages/man1/install.1.html

Otherwise, when executing:
```
make HOST=aarcj64-none-linux-gnu CROSS_COMPILE=aarch64-none-linux-gnu- &&\
make HOST=aarcj64-none-linux-gnu CROSS_COMPILE=aarch64-none-linux-gnu- DESTDIR=~/test install
```
output:
```
install -c -m 755 -s lspci /root/workspace/pciutils/install/usr/local/bin
strip: Unable to recognise the format of the input file `/root/workspace/pciutils/install/usr/local/bin/lspci'
install: strip process terminated abnormally
make: *** [Makefile:151: install] Error 1
```
