### PR TITLE
lspci: Add support for the DOE Discovery options

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -1393,6 +1393,12 @@
 #define  PCI_DOE_STS_INT		0x2	/* DOE Interrupt Status */
 #define  PCI_DOE_STS_ERROR		0x3	/* DOE Error */
 #define  PCI_DOE_STS_OBJECT_READY	0x80000000 /* Data Object Ready */
+#define PCI_DOE_WRITE_MAILBOX		0x10	/* DOE Write Data Mailbox Register */
+#define PCI_DOE_READ_MAILBOX		0x14	/* DOE Read Data Mailbox Register */
+
+#define PCI_DOE_DISCOVERY_RESPONSE_VENDOR_ID	0xFFFF
+#define PCI_DOE_DISCOVERY_RESPONSE_OBJ_PROTOCOL	0xFF0000
+#define PCI_DOE_DISCOVERY_RESPONSE_NEXT_INDX	0xFF000000
 
 /*
  * The PCI interface treats multi-function devices as independent


### PR DESCRIPTION
The PCIe 6 specification added support for the Data Object Exchange (DOE). When DOE is supported the Discovery Data Object Protocol must be implemented. The protocol allows a requester to obtain information about the other DOE protocols supported by the device.

This patch adds support for querying the list of DOE Discovery Data Object Protocols supported by the device.

This unfortunately does require writing to the device, as we can't query the information without sending data objects to the device.