### PR TITLE
RFC: lspci: Use mangled vendor/device ID when examining vendor caps

### DIFF
--- a/ls-caps-vendor.c
+++ b/ls-caps-vendor.c
@@ -64,11 +64,11 @@ show_vendor_caps_virtio(struct device *d, int where, int cap)
 static int
 do_show_vendor_caps(struct device *d, int where, int cap)
 {
-  switch (get_conf_word(d, PCI_VENDOR_ID))
+  switch (d->dev->vendor_id)
     {
     case 0x1af4: /* Red Hat */
-      if (get_conf_word(d, PCI_DEVICE_ID) >= 0x1000 &&
-	  get_conf_word(d, PCI_DEVICE_ID) <= 0x107f)
+      if (d->dev->device_id >= 0x1000 &&
+	  d->dev->device_id <= 0x107f)
 	return show_vendor_caps_virtio(d, where, cap);
       break;
     }


### PR DESCRIPTION
Given that PCI VFs are expected to have a vendor and device ID of 0xffff, when examining vendor capabilities use the mangled vendor and device IDs (typically copied from the PF) rather than those read from the VF configuration space.