### PR TITLE
Add support for 32.0 GT/s header

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -254,6 +254,7 @@
 #define PCI_EXT_CAP_ID_LMR	0x27	/* Lane Margining at Receiver */
 #define PCI_EXT_CAP_ID_HIER_ID	0x28	/* Hierarchy ID */
 #define PCI_EXT_CAP_ID_NPEM	0x29	/* Native PCIe Enclosure Management */
+#define PCI_EXT_CAP_ID_32GT	0x2a	/* Physical Layer 32.0 GT/s */
 #define PCI_EXT_CAP_ID_DOE	0x2e	/* Data Object Exchange */
 
 /*** Definitions of capabilities ***/

--- a/ls-ecaps.c
+++ b/ls-ecaps.c
@@ -1556,6 +1556,9 @@ show_ext_caps(struct device *d, int type)
 	  case PCI_EXT_CAP_ID_NPEM:
 	    printf("Native PCIe Enclosure Management <?>\n");
 	    break;
+      case PCI_EXT_CAP_ID_32GT:
+	    printf("Physical Layer 32.0 GT/s <?>\n");
+        break;
 	  case PCI_EXT_CAP_ID_DOE:
 	    cap_doe(d, where);
 	    break;


### PR DESCRIPTION
PCie Gen5 becoming more and more popular.
Let's add header parser for  'Physical Layer 32.0 GT/s Extended Capability Header'