### PR TITLE
Fix compile warnings about unused variables

### DIFF
--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -566,7 +566,7 @@ static int sysfs_write(struct pci_dev *d, int pos, byte *buf, int len)
 
 /* pread() is not available and do_read() only works for a single fd, so we
  * cannot implement read_vpd properly. */
-static int sysfs_read_vpd(struct pci_dev *d, int pos, byte *buf, int len)
+static int sysfs_read_vpd(struct pci_dev *d UNUSED, int pos UNUSED, byte *buf UNUSED, int len UNUSED)
 {
   return 0;
 }


### PR DESCRIPTION
```
sysfs.c: In function 'sysfs_read_vpd':
sysfs.c:569:43: warning: unused parameter 'd' [-Wunused-parameter]
 static int sysfs_read_vpd(struct pci_dev *d, int pos, byte *buf, int len)
                                           ^
sysfs.c:569:50: warning: unused parameter 'pos' [-Wunused-parameter]
 static int sysfs_read_vpd(struct pci_dev *d, int pos, byte *buf, int len)
                                                  ^~~
sysfs.c:569:61: warning: unused parameter 'buf' [-Wunused-parameter]
 static int sysfs_read_vpd(struct pci_dev *d, int pos, byte *buf, int len)
                                                             ^~~
sysfs.c:569:70: warning: unused parameter 'len' [-Wunused-parameter]
 static int sysfs_read_vpd(struct pci_dev *d, int pos, byte *buf, int len)
                                                                      ^~~
```