### PR TITLE
Show ClassCode, ProgIf, and RevID in show_verbose

### DIFF
--- a/lspci.c
+++ b/lspci.c
@@ -806,6 +806,8 @@ show_verbose(struct device *d)
     PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE | PCI_FILL_IOMMU_GROUP |
     PCI_FILL_BRIDGE_BASES | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS);
 
+  printf("\tClassCode=%#x ProgIf=%#x RevId=%#x\n", class, p->prog_if, p->rev_id);
+
   switch (htype)
     {
     case PCI_HEADER_TYPE_NORMAL:


### PR DESCRIPTION
Show ClassCode, ProgIf, and RevID hex value in show_verbose are useful for debugging PCI module driver.