### PR TITLE
lspci: add VirtIO SharedMemory capability support

### DIFF
--- a/ls-caps-vendor.c
+++ b/ls-caps-vendor.c
@@ -19,6 +19,10 @@ show_vendor_caps_virtio(struct device *d, int where, int cap)
   int length = BITS(cap, 0, 8);
   int type = BITS(cap, 8, 8);
   char *tname;
+  u32 offset;
+  u32 size;
+  u32 offset_hi;
+  u32 size_hi;
 
   if (length < 16)
     return 0;
@@ -39,6 +43,9 @@ show_vendor_caps_virtio(struct device *d, int where, int cap)
     case 4:
       tname = "DeviceCfg";
       break;
+    case 8:
+      tname = "SharedMemory";
+      break;
     default:
       tname = "<unknown>";
       break;
@@ -49,10 +56,20 @@ show_vendor_caps_virtio(struct device *d, int where, int cap)
   if (verbose < 2)
     return 1;
 
-  printf("\t\tBAR=%d offset=%08x size=%08x",
-	 get_conf_byte(d, where +  4),
-	 get_conf_long(d, where +  8),
-	 get_conf_long(d, where + 12));
+  offset = get_conf_long(d, where + 8);
+  size = get_conf_long(d, where + 12);
+  if (type != 8)  
+    printf("\t\tBAR=%d offset=%08x size=%08x",
+      get_conf_byte(d, where +  4), offset, size);
+  else {
+    offset_hi = get_conf_long(d, where + 16);
+    size_hi = get_conf_long(d, where + 20);
+    printf("\t\tBAR=%d offset=%016lx size=%016lx id=%d",
+      get_conf_byte(d, where +  4),
+      (u64) offset | (u64) offset_hi << 32,
+      (u64) size | (u64) size_hi << 32,
+      get_conf_byte(d, where + 5));
+  }
 
   if (type == 2 && length >= 20)
     printf(" multiplier=%08x", get_conf_long(d, where+16));


### PR DESCRIPTION
This patch adds the support for VirtIO share memory capability [1]. A shared memory region is defined in a `struct virtio_pci_cap64` where the highest 32 bits of `offset` and `size` are appened to the original `struct virtio_pci_cap`.

With this patch, a VirtIO PMEM device (ID 27) shows like the following:

```
00:02.0 Class ffff: Device 1af4:105b (rev 01)
        Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
        Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
        Latency: 0
        Region 0: Memory at 100001000 (64-bit, non-prefetchable) [size=4K]
        Region 2: Memory at 101000000 (64-bit, non-prefetchable) [size=16M]
        Capabilities: [40] Vendor Specific Information: VirtIO: CommonCfg
                BAR=0 offset=00000000 size=0000003c
        Capabilities: [50] Vendor Specific Information: VirtIO: ISR
                BAR=0 offset=0000003c size=00000001
        Capabilities: [60] Vendor Specific Information: VirtIO: Notify
                BAR=0 offset=00000040 size=00000002 multiplier=00000002
        Capabilities: [78] MSI-X: Enable+ Count=2 Masked-
                Vector table: BAR=0 offset=00000058
                PBA: BAR=0 offset=00000078
        Capabilities: [88] Vendor Specific Information: VirtIO: DeviceCfg
                BAR=0 offset=00000044 size=00000010
        Capabilities: [98] Vendor Specific Information: VirtIO: SharedMemory
                BAR=2 offset=0000000000000000 size=0000000001000000 id=0
        Kernel driver in use: virtio-pci
```

[1] Sec 4.1.4.7 https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-1240004