### PR TITLE
Add display function for cxl1.1 device link status information.

### DIFF
--- a/lib/pci.h
+++ b/lib/pci.h
@@ -159,9 +159,9 @@ struct pci_dev {
   u16 subsys_vendor_id, subsys_id;	/* Subsystem vendor id and subsystem id */
   struct pci_dev *parent;		/* Parent device, does not have to be always accessible */
   int no_config_access;			/* No access to config space for this device */
-  u32 rcd_link_cap;
-  u16 rcd_link_status;
-  u16 rcd_link_ctrl;
+  u32 rcd_link_cap;     /* Link Capabilities register for RCD */
+  u16 rcd_link_status;  /* Link Status register for RCD */
+  u16 rcd_link_ctrl;    /* Link Control register for RCD */
 
   /* Fields used internally */
   struct pci_access *access;
@@ -190,8 +190,6 @@ int pci_write_long(struct pci_dev *, int pos, u32 data) PCI_ABI;
 /* Configuration space as a sequence of bytes (little-endian) */
 int pci_read_block(struct pci_dev *, int pos, u8 *buf, int len) PCI_ABI;
 int pci_write_block(struct pci_dev *, int pos, u8 *buf, int len) PCI_ABI;
-
-int get_rcd_sysfs_obj_file(struct pci_dev *d, char *object, char *result) PCI_ABI;
 
 /*
  * Most device properties take some effort to obtain, so libpci does not

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -159,6 +159,9 @@ struct pci_dev {
   u16 subsys_vendor_id, subsys_id;	/* Subsystem vendor id and subsystem id */
   struct pci_dev *parent;		/* Parent device, does not have to be always accessible */
   int no_config_access;			/* No access to config space for this device */
+  u32 rcd_link_cap;
+  u16 rcd_link_status;
+  u16 rcd_link_ctrl;
 
   /* Fields used internally */
   struct pci_access *access;
@@ -187,6 +190,8 @@ int pci_write_long(struct pci_dev *, int pos, u32 data) PCI_ABI;
 /* Configuration space as a sequence of bytes (little-endian) */
 int pci_read_block(struct pci_dev *, int pos, u8 *buf, int len) PCI_ABI;
 int pci_write_block(struct pci_dev *, int pos, u8 *buf, int len) PCI_ABI;
+
+int get_rcd_sysfs_obj_file(struct pci_dev *d, char *object, char *result) PCI_ABI;
 
 /*
  * Most device properties take some effort to obtain, so libpci does not
@@ -231,6 +236,7 @@ char *pci_get_string_property(struct pci_dev *d, u32 prop) PCI_ABI;
 #define PCI_FILL_SUBSYS		0x00040000      /* subsys_vendor_id and subsys_id */
 #define PCI_FILL_PARENT		0x00080000
 #define PCI_FILL_DRIVER		0x00100000      /* OS driver currently in use (string property) */
+#define PCI_FILL_RCD_LNK	0x00200000      /* CXL RCD Link status properties */
 
 void pci_setup_cache(struct pci_dev *, u8 *cache, int len) PCI_ABI;
 

--- a/lib/sysfs.c
+++ b/lib/sysfs.c
@@ -483,6 +483,17 @@ sysfs_fill_info(struct pci_dev *d, unsigned int flags)
         clear_fill(d, PCI_FILL_DRIVER);
     }
 
+  if (want_fill(d, flags, PCI_FILL_RCD_LNK))
+    {
+      char buf[OBJBUFSIZE];
+      if (sysfs_get_string(d, "rcd_link_cap", buf, 0))
+        d->rcd_link_cap = strtoul(buf, NULL, 16);
+      if (sysfs_get_string(d, "rcd_link_ctrl", buf, 0))
+        d->rcd_link_ctrl = strtoul(buf, NULL, 16);
+      if (sysfs_get_string(d, "rcd_link_status", buf, 0))
+        d->rcd_link_status = strtoul(buf, NULL, 16);
+    }
+
   pci_generic_fill_info(d, flags);
 }
 

--- a/ls-caps.c
+++ b/ls-caps.c
@@ -10,7 +10,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <fcntl.h>
 #include <stdlib.h>
 
 #include "lspci.h"
@@ -1392,7 +1391,8 @@ static void cap_express_slot2(struct device *d UNUSED, int where UNUSED)
   /* No capabilities that require this field in PCIe rev2.0 spec. */
 }
 
-static void cap_express_link_rcd(struct device *d){
+static void cap_express_link_rcd(struct device *d)
+{
   u32 t, aspm, cap_speed, cap_width, sta_speed, sta_width;
   u16 w;
   struct pci_dev *pdev = d->dev;
@@ -1404,52 +1404,51 @@ static void cap_express_link_rcd(struct device *d){
   cap_speed = t & PCI_EXP_LNKCAP_SPEED;
   cap_width = (t & PCI_EXP_LNKCAP_WIDTH) >> 4;
   printf("\t\tLnkCap:\tPort #%d, Speed %s, Width x%d, ASPM %s",
-  t >> 24,
-  link_speed(cap_speed), cap_width,
-  aspm_support(aspm));
-  if (aspm)
-    {
+   t >> 24,
+   link_speed(cap_speed), cap_width,
+   aspm_support(aspm));
+  if (aspm) {
       printf(", Exit Latency ");
       if (aspm & 1)
-  printf("L0s %s", latency_l0s((t & PCI_EXP_LNKCAP_L0S) >> 12));
+        printf("L0s %s", latency_l0s((t & PCI_EXP_LNKCAP_L0S) >> 12));
       if (aspm & 2)
-  printf("%sL1 %s", (aspm & 1) ? ", " : "",
+        printf("%sL1 %s", (aspm & 1) ? ", " : "",
       latency_l1((t & PCI_EXP_LNKCAP_L1) >> 15));
-    }
+  }
   printf("\n");
   printf("\t\t\tClockPM%c Surprise%c LLActRep%c BwNot%c ASPMOptComp%c\n",
-  FLAG(t, PCI_EXP_LNKCAP_CLOCKPM),
-  FLAG(t, PCI_EXP_LNKCAP_SURPRISE),
-  FLAG(t, PCI_EXP_LNKCAP_DLLA),
-  FLAG(t, PCI_EXP_LNKCAP_LBNC),
-  FLAG(t, PCI_EXP_LNKCAP_AOC));
+   FLAG(t, PCI_EXP_LNKCAP_CLOCKPM),
+   FLAG(t, PCI_EXP_LNKCAP_SURPRISE),
+   FLAG(t, PCI_EXP_LNKCAP_DLLA),
+   FLAG(t, PCI_EXP_LNKCAP_LBNC),
+   FLAG(t, PCI_EXP_LNKCAP_AOC));
 
   w = pdev->rcd_link_ctrl;
   printf("\t\tLnkCtl:\tASPM %s;", aspm_enabled(w & PCI_EXP_LNKCTL_ASPM));
   printf(" Disabled%c CommClk%c\n\t\t\tExtSynch%c ClockPM%c AutWidDis%c BWInt%c AutBWInt%c\n",
-  FLAG(w, PCI_EXP_LNKCTL_DISABLE),
-  FLAG(w, PCI_EXP_LNKCTL_CLOCK),
-  FLAG(w, PCI_EXP_LNKCTL_XSYNCH),
-  FLAG(w, PCI_EXP_LNKCTL_CLOCKPM),
-  FLAG(w, PCI_EXP_LNKCTL_HWAUTWD),
-  FLAG(w, PCI_EXP_LNKCTL_BWMIE),
-  FLAG(w, PCI_EXP_LNKCTL_AUTBWIE));
+   FLAG(w, PCI_EXP_LNKCTL_DISABLE),
+   FLAG(w, PCI_EXP_LNKCTL_CLOCK),
+   FLAG(w, PCI_EXP_LNKCTL_XSYNCH),
+   FLAG(w, PCI_EXP_LNKCTL_CLOCKPM),
+   FLAG(w, PCI_EXP_LNKCTL_HWAUTWD),
+   FLAG(w, PCI_EXP_LNKCTL_BWMIE),
+   FLAG(w, PCI_EXP_LNKCTL_AUTBWIE));
 
   w = pdev->rcd_link_status;
   sta_speed = w & PCI_EXP_LNKSTA_SPEED;
   sta_width = (w & PCI_EXP_LNKSTA_WIDTH) >> 4;
   printf("\t\tLnkSta:\tSpeed %s%s, Width x%d%s\n",
-  link_speed(sta_speed),
-  link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_speed, cap_speed),
-  sta_width,
-  link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_width, cap_width));
+   link_speed(sta_speed),
+   link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_speed, cap_speed),
+   sta_width,
+   link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_width, cap_width));
   printf("\t\t\tTrErr%c Train%c SlotClk%c DLActive%c BWMgmt%c ABWMgmt%c\n",
-  FLAG(w, PCI_EXP_LNKSTA_TR_ERR),
-  FLAG(w, PCI_EXP_LNKSTA_TRAIN),
-  FLAG(w, PCI_EXP_LNKSTA_SL_CLK),
-  FLAG(w, PCI_EXP_LNKSTA_DL_ACT),
-  FLAG(w, PCI_EXP_LNKSTA_BWMGMT),
-  FLAG(w, PCI_EXP_LNKSTA_AUTBW));
+   FLAG(w, PCI_EXP_LNKSTA_TR_ERR),
+   FLAG(w, PCI_EXP_LNKSTA_TRAIN),
+   FLAG(w, PCI_EXP_LNKSTA_SL_CLK),
+   FLAG(w, PCI_EXP_LNKSTA_DL_ACT),
+   FLAG(w, PCI_EXP_LNKSTA_BWMGMT),
+   FLAG(w, PCI_EXP_LNKSTA_AUTBW));
 
   return;
 }

--- a/ls-caps.c
+++ b/ls-caps.c
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <fcntl.h>
+#include <stdlib.h>
 
 #include "lspci.h"
 
@@ -1390,6 +1392,68 @@ static void cap_express_slot2(struct device *d UNUSED, int where UNUSED)
   /* No capabilities that require this field in PCIe rev2.0 spec. */
 }
 
+static void cap_express_link_rcd(struct device *d){
+  u32 t, aspm, cap_speed, cap_width, sta_speed, sta_width;
+  u16 w;
+  struct pci_dev *pdev = d->dev;
+
+  if (!pdev->rcd_link_cap)
+    return;
+  t = pdev->rcd_link_cap;
+  aspm = (t & PCI_EXP_LNKCAP_ASPM) >> 10;
+  cap_speed = t & PCI_EXP_LNKCAP_SPEED;
+  cap_width = (t & PCI_EXP_LNKCAP_WIDTH) >> 4;
+  printf("\t\tLnkCap:\tPort #%d, Speed %s, Width x%d, ASPM %s",
+  t >> 24,
+  link_speed(cap_speed), cap_width,
+  aspm_support(aspm));
+  if (aspm)
+    {
+      printf(", Exit Latency ");
+      if (aspm & 1)
+  printf("L0s %s", latency_l0s((t & PCI_EXP_LNKCAP_L0S) >> 12));
+      if (aspm & 2)
+  printf("%sL1 %s", (aspm & 1) ? ", " : "",
+      latency_l1((t & PCI_EXP_LNKCAP_L1) >> 15));
+    }
+  printf("\n");
+  printf("\t\t\tClockPM%c Surprise%c LLActRep%c BwNot%c ASPMOptComp%c\n",
+  FLAG(t, PCI_EXP_LNKCAP_CLOCKPM),
+  FLAG(t, PCI_EXP_LNKCAP_SURPRISE),
+  FLAG(t, PCI_EXP_LNKCAP_DLLA),
+  FLAG(t, PCI_EXP_LNKCAP_LBNC),
+  FLAG(t, PCI_EXP_LNKCAP_AOC));
+
+  w = pdev->rcd_link_ctrl;
+  printf("\t\tLnkCtl:\tASPM %s;", aspm_enabled(w & PCI_EXP_LNKCTL_ASPM));
+  printf(" Disabled%c CommClk%c\n\t\t\tExtSynch%c ClockPM%c AutWidDis%c BWInt%c AutBWInt%c\n",
+  FLAG(w, PCI_EXP_LNKCTL_DISABLE),
+  FLAG(w, PCI_EXP_LNKCTL_CLOCK),
+  FLAG(w, PCI_EXP_LNKCTL_XSYNCH),
+  FLAG(w, PCI_EXP_LNKCTL_CLOCKPM),
+  FLAG(w, PCI_EXP_LNKCTL_HWAUTWD),
+  FLAG(w, PCI_EXP_LNKCTL_BWMIE),
+  FLAG(w, PCI_EXP_LNKCTL_AUTBWIE));
+
+  w = pdev->rcd_link_status;
+  sta_speed = w & PCI_EXP_LNKSTA_SPEED;
+  sta_width = (w & PCI_EXP_LNKSTA_WIDTH) >> 4;
+  printf("\t\tLnkSta:\tSpeed %s%s, Width x%d%s\n",
+  link_speed(sta_speed),
+  link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_speed, cap_speed),
+  sta_width,
+  link_compare(PCI_EXP_TYPE_ROOT_INT_EP, sta_width, cap_width));
+  printf("\t\t\tTrErr%c Train%c SlotClk%c DLActive%c BWMgmt%c ABWMgmt%c\n",
+  FLAG(w, PCI_EXP_LNKSTA_TR_ERR),
+  FLAG(w, PCI_EXP_LNKSTA_TRAIN),
+  FLAG(w, PCI_EXP_LNKSTA_SL_CLK),
+  FLAG(w, PCI_EXP_LNKSTA_DL_ACT),
+  FLAG(w, PCI_EXP_LNKSTA_BWMGMT),
+  FLAG(w, PCI_EXP_LNKSTA_AUTBW));
+
+  return;
+}
+
 static int
 cap_express(struct device *d, int where, int cap)
 {
@@ -1454,6 +1518,9 @@ cap_express(struct device *d, int where, int cap)
   cap_express_dev(d, where, type);
   if (link)
     cap_express_link(d, where, type);
+  else if (d->dev->rcd_link_cap)
+    cap_express_link_rcd(d);
+   
   if (slot)
     cap_express_slot(d, where);
   if (type == PCI_EXP_TYPE_ROOT_PORT || type == PCI_EXP_TYPE_ROOT_EC)

--- a/lspci.c
+++ b/lspci.c
@@ -146,7 +146,7 @@ scan_device(struct pci_dev *p)
 	d->config_cached += 64;
     }
   pci_setup_cache(p, d->config, d->config_cached);
-  pci_fill_info(p, PCI_FILL_IDENT | PCI_FILL_CLASS | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS | (need_topology ? PCI_FILL_PARENT : 0));
+  pci_fill_info(p, PCI_FILL_IDENT | PCI_FILL_CLASS | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS | PCI_FILL_RCD_LNK | (need_topology ? PCI_FILL_PARENT : 0));
   return d;
 }
 

--- a/lspci.c
+++ b/lspci.c
@@ -146,7 +146,7 @@ scan_device(struct pci_dev *p)
 	d->config_cached += 64;
     }
   pci_setup_cache(p, d->config, d->config_cached);
-  pci_fill_info(p, PCI_FILL_IDENT | PCI_FILL_CLASS | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS | PCI_FILL_RCD_LNK | (need_topology ? PCI_FILL_PARENT : 0));
+  pci_fill_info(p, PCI_FILL_IDENT | PCI_FILL_CLASS | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS | (need_topology ? PCI_FILL_PARENT : 0));
   return d;
 }
 
@@ -805,7 +805,7 @@ show_verbose(struct device *d)
 
   pci_fill_info(p, PCI_FILL_IRQ | PCI_FILL_BASES | PCI_FILL_ROM_BASE | PCI_FILL_SIZES |
     PCI_FILL_PHYS_SLOT | PCI_FILL_NUMA_NODE | PCI_FILL_DT_NODE | PCI_FILL_IOMMU_GROUP |
-    PCI_FILL_BRIDGE_BASES | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS);
+    PCI_FILL_BRIDGE_BASES | PCI_FILL_CLASS_EXT | PCI_FILL_SUBSYS | PCI_FILL_RCD_LNK);
 
   switch (htype)
     {


### PR DESCRIPTION
CXL devices are extensions of PCIe. Therefore, from CXL2.0 onwards, the link status can be output in the same way as traditional PCIe.
However, unlike devices from CXL2.0 onwards, CXL1.1 requires a different method to obtain the link status from traditional PCIe.
This is because the link status of the CXL1.1 device is not mapped in the configuration space (as per cxl3.0 specification 8.1).
Instead, the configuration space containing the link status is mapped to the memory mapped register region (as per cxl3.0 specification 8.2, Table 8-18). 
Therefore, the current lspci has a problem where it does not display the link status of the CXL1.1 device. 
Solve these issues with sysfs attributes to export the status registers hidden in the RCRB.

We are currently adding a feature to the Linux kernel driver that will output the link status information of the cxl1.1 device to sysfs. [1]
As the output format for sysfs is becoming finalized, we have begun implementing the functionality of lspci based on this output.


[1] https://lore.kernel.org/linux-cxl/20240510073710.98953-1-kobayashi.da-06@fujitsu.com/T/#u

