### PR TITLE
dump: allow 6-digit domains

### DIFF
--- a/lib/dump.c
+++ b/lib/dump.c
@@ -83,7 +83,8 @@ dump_init(struct pci_access *a)
       mn = 0;
       if (dump_validate(buf, "##:##.# ") && sscanf(buf, "%x:%x.%d", &bn, &dn, &fn) == 3 ||
 	  dump_validate(buf, "####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4 ||
-	  dump_validate(buf, "#####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4)
+	  dump_validate(buf, "#####:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4 ||
+	  dump_validate(buf, "######:##:##.# ") && sscanf(buf, "%x:%x:%x.%d", &mn, &bn, &dn, &fn) == 4)
 	{
 	  dev = pci_get_dev(a, mn, bn, dn, fn);
 	  dump_alloc_data(dev, 256);


### PR DESCRIPTION
The SPDK VMD driver assigns domains for the devices behind a VMD by concatenating bus/device/function of the VMD, each on a separate byte. For instance, a device behind a VMD with an address of 5d:05.5 would be assigned domain 5d0505.