### PR TITLE
lspci: Added decodes for Physical Layer 16/32/64 extended capabilities registers

### DIFF
--- a/lib/header.h
+++ b/lib/header.h
@@ -1367,6 +1367,46 @@
 #define PCI_SEC_LANE_ERR	8	/* Lane Error status register */
 #define PCI_SEC_LANE_EQU_CTRL	12	/* Lane Equalization control register */
 
+/* Physical Layer 16 GT/s Extended Capability */
+#define PCI_16GT_CAP		0x04	/* 16 GT/s Capabilities Register */
+#define PCI_16GT_CTL		0x08	/* 16 GT/s Control Register */
+#define PCI_16GT_STATUS		0x0C	/* 16 GT/s Status Register */
+#define  PCI_16GT_STATUS_EQU_COMP	0x0001	/* Equalization 16 GT/s Complete */
+#define  PCI_16GT_STATUS_EQU_PHASE1	0x0002	/* Equalization 16 GT/s Phase 1 Successful */
+#define  PCI_16GT_STATUS_EQU_PHASE2	0x0004	/* Equalization 16 GT/s Phase 2 Successful */
+#define  PCI_16GT_STATUS_EQU_PHASE3	0x0008	/* Equalization 16 GT/s Phase 3 Successful */
+#define  PCI_16GT_STATUS_EQU_REQ	0x0010	/* Link Equalization Request 16 GT/s */
+#define PCI_16GT_LDPM		0x10	/* 16 GT/s Local Data Parity Mismatch Status Register */
+#define PCI_16GT_FRDPM		0x14	/* 16 GT/s First Retimer Data Parity Mismatch Status Register */
+#define PCI_16GT_SRDPM		0x18	/* 16 GT/s Second Retimer Data Parity Mismatch Status Register */
+
+/* Physical Layer 32 GT/s Extended Capability */
+#define PCI_32GT_CAP		0x04	/* 32 GT/s Capabilities Register */
+#define  PCI_32GT_CAP_EQU_BYPASS	0x0001	/* Equalization bypass to highest rate Supported */
+#define  PCI_32GT_CAP_NO_EQU_NEEDED	0x0002	/* No Equalization Needed Supported */
+#define  PCI_32GT_CAP_MOD_TS_MODE_0	0x0100	/* Modified TS Usage Mode 0 Supported - PCI Express */
+#define  PCI_32GT_CAP_MOD_TS_MODE_1	0x0200	/* Modified TS Usage Mode 1 Supported - Training Set Message */
+#define  PCI_32GT_CAP_MOD_TS_MODE_2	0x0400	/* Modified TS Usage Mode 2 Supported - Alternate Protocol */
+#define PCI_32GT_CTL		0x08	/* 32 GT/s Control Register */
+#define  PCI_32GT_CTL_EQU_BYPASS_DIS	0x1	/* Equalization bypass to highest rate Disable */
+#define  PCI_32GT_CTL_NO_EQU_NEEDED_DIS	0x2	/* No Equalization Needed Disable */
+#define  PCI_32GT_CTL_MOD_TS_MODE(x) (((x) >> 8) & 0x7)	/* Modified TS Usage Mode Selected */
+#define PCI_32GT_STATUS		0x0C	/* 32 GT/s Status Register */
+#define  PCI_32GT_STATUS_EQU_COMP	0x0001	/* Equalization 32 GT/s Complete */
+#define  PCI_32GT_STATUS_EQU_PHASE1	0x0002	/* Equalization 32 GT/s Phase 1 Successful */
+#define  PCI_32GT_STATUS_EQU_PHASE2	0x0004	/* Equalization 32 GT/s Phase 2 Successful */
+#define  PCI_32GT_STATUS_EQU_PHASE3	0x0008	/* Equalization 32 GT/s Phase 3 Successful */
+#define  PCI_32GT_STATUS_EQU_REQ	0x0010	/* Link Equalization Request 32 GT/s */
+#define  PCI_32GT_STATUS_MOD_TS		0x0020	/* Modified TS Received */
+#define  PCI_32GT_STATUS_RCV_ENH_LINK(x) (((x) >> 6) & 0x3)	/* Received Enhanced Link Behavior Control */
+#define  PCI_32GT_STATUS_TX_PRE_ON	0x0100	/* Transmitter Precoding On */
+#define  PCI_32GT_STATUS_TX_PRE_REQ	0x0200	/* Transmitter Precoding Request */
+#define  PCI_32GT_STATUS_NO_EQU 	0x0400	/* No Equalization Needed Received */
+#define PCI_32GT_RXMODTS1	0x10	/* Received Modified TS Data 1 Register */
+#define PCI_32GT_RXMODTS2	0x14	/* Received Modified TS Data 2 Register */
+#define PCI_32GT_TXMODTS1	0x18	/* Transmitted Modified TS Data 1 Register */
+#define PCI_32GT_TXMODTS2	0x1C	/* Transmitted Modified TS Data 2 Register */
+
 /* Process Address Space ID */
 #define PCI_PASID_CAP		0x04	/* PASID feature register */
 #define  PCI_PASID_CAP_EXEC	0x02	/* Exec permissions Supported */

--- a/lib/header.h
+++ b/lib/header.h
@@ -257,6 +257,7 @@
 #define PCI_EXT_CAP_ID_32GT	0x2a	/* Physical Layer 32.0 GT/s */
 #define PCI_EXT_CAP_ID_DOE	0x2e	/* Data Object Exchange */
 #define PCI_EXT_CAP_ID_IDE	0x30	/* Integrity and Data Encryption */
+#define PCI_EXT_CAP_ID_64GT	0x31	/* Physical Layer 64.0 GT/s */
 
 /*** Definitions of capabilities ***/
 
@@ -1406,6 +1407,19 @@
 #define PCI_32GT_RXMODTS2	0x14	/* Received Modified TS Data 2 Register */
 #define PCI_32GT_TXMODTS1	0x18	/* Transmitted Modified TS Data 1 Register */
 #define PCI_32GT_TXMODTS2	0x1C	/* Transmitted Modified TS Data 2 Register */
+
+/* Physical Layer 64 GT/s Extended Capability */
+#define PCI_64GT_CAP		0x04	/* 64 GT/s Capabilities Register */
+#define PCI_64GT_CTL		0x08	/* 64 GT/s Control Register */
+#define PCI_64GT_STATUS		0x0C	/* 64 GT/s Status Register */
+#define  PCI_64GT_STATUS_EQU_COMP	0x0001	/* Equalization 64 GT/s Complete */
+#define  PCI_64GT_STATUS_EQU_PHASE1	0x0002	/* Equalization 64 GT/s Phase 1 Successful */
+#define  PCI_64GT_STATUS_EQU_PHASE2	0x0004	/* Equalization 64 GT/s Phase 2 Successful */
+#define  PCI_64GT_STATUS_EQU_PHASE3	0x0008	/* Equalization 64 GT/s Phase 3 Successful */
+#define  PCI_64GT_STATUS_EQU_REQ	0x0010	/* Link Equalization Request 64 GT/s */
+#define  PCI_64GT_STATUS_TX_PRE_ON	0x0020	/* Transmitter Precoding On */
+#define  PCI_64GT_STATUS_TX_PRE_REQ	0x0040	/* Transmitter Precoding Request */
+#define  PCI_64GT_STATUS_NO_EQU 	0x0080	/* No Equalization Needed Received */
 
 /* Process Address Space ID */
 #define PCI_PASID_CAP		0x04	/* PASID feature register */

--- a/ls-ecaps.c
+++ b/ls-ecaps.c
@@ -816,6 +816,33 @@ cap_phy_32gt(struct device *d, int where)
 }
 
 static void
+cap_phy_64gt(struct device *d, int where)
+{
+  printf("Physical Layer 64.0 GT/s\n");
+
+  if (verbose < 2)
+    return;
+
+  if (!config_fetch(d, where + PCI_64GT_CAP, 0x0C)) {
+    printf("\t\t<unreadable>\n");
+    return;
+  }
+
+  u32 status = get_conf_long(d, where + PCI_64GT_STATUS);
+
+  printf("\t\tPhy64Sta: EquComplete%c EquPhase1%c EquPhase2%c EquPhase3%c LinkEquRequest%c\n"
+         "\t\t\t  TxPrecodeOn%c TxPrecodeReq%c NoEqualizationNeededRecv%c\n",
+         FLAG(status, PCI_64GT_STATUS_EQU_COMP),
+         FLAG(status, PCI_64GT_STATUS_EQU_PHASE1),
+         FLAG(status, PCI_64GT_STATUS_EQU_PHASE2),
+         FLAG(status, PCI_64GT_STATUS_EQU_PHASE3),
+         FLAG(status, PCI_64GT_STATUS_EQU_REQ),
+         FLAG(status, PCI_64GT_STATUS_TX_PRE_ON),
+         FLAG(status, PCI_64GT_STATUS_TX_PRE_REQ),
+         FLAG(status, PCI_64GT_STATUS_NO_EQU));
+}
+
+static void
 cxl_range(u64 base, u64 size, int n)
 {
   u32 interleave[] = { 0, 256, 4096, 512, 1024, 2048, 8192, 16384 };
@@ -1941,6 +1968,9 @@ show_ext_caps(struct device *d, int type)
 	    break;
 	  case PCI_EXT_CAP_ID_IDE:
 	    cap_ide(d, where);
+	    break;
+	  case PCI_EXT_CAP_ID_64GT:
+	    cap_phy_64gt(d, where);
 	    break;
 	  default:
 	    printf("Extended Capability ID %#02x\n", id);

--- a/setpci.c
+++ b/setpci.c
@@ -398,6 +398,7 @@ static const struct reg_name pci_reg_names[] = {
   { 0x20029,	0, 0, 0x0, "ECAP_NPEM" },
   { 0x2002a,	0, 0, 0x0, "ECAP_32GT" },
   { 0x20030,	0, 0, 0x0, "ECAP_IDE" },
+  { 0x20031,	0, 0, 0x0, "ECAP_64GT" },
   {       0,    0, 0, 0x0, NULL }
 };
 

--- a/setpci.c
+++ b/setpci.c
@@ -396,6 +396,7 @@ static const struct reg_name pci_reg_names[] = {
   { 0x20027,	0, 0, 0x0, "ECAP_LMR" },
   { 0x20028,	0, 0, 0x0, "ECAP_HIER_ID" },
   { 0x20029,	0, 0, 0x0, "ECAP_NPEM" },
+  { 0x2002a,	0, 0, 0x0, "ECAP_32GT" },
   { 0x20030,	0, 0, 0x0, "ECAP_IDE" },
   {       0,    0, 0, 0x0, NULL }
 };


### PR DESCRIPTION
Added register field decodes in lspci verbose output for the following extended capability registers:
- Physical Layer 16 GT/s
- Physical Layer 32 GT/s
- Physical Layer 64 GT/s

Also added missing register names to setpci for these registers.