### PR TITLE
Use snprintf instead of sprintf to prevent buffer overruns

### DIFF
--- a/bitops.h
+++ b/bitops.h
@@ -34,6 +34,6 @@
   (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
 
 #define TABLE(tab, x, buf)                                                                         \
-  ((x) < sizeof(tab) / sizeof((tab)[0]) ? (tab)[x] : (sprintf((buf), "??%d", (x)), (buf)))
+  ((x) < sizeof(tab) / sizeof((tab)[0]) ? (tab)[x] : (snprintf((buf), sizeof(buf), "??%d", (x)), (buf)))
 
 #endif

--- a/setpci.c
+++ b/setpci.c
@@ -118,7 +118,7 @@ exec_op(struct op *op, struct pci_dev *dev)
   int width = op->width;
   char slot[16];
 
-  sprintf(slot, "%04x:%02x:%02x.%x", dev->domain, dev->bus, dev->dev, dev->func);
+  snprintf(slot, sizeof(slot), "%04x:%02x:%02x.%x", dev->domain, dev->bus, dev->dev, dev->func);
   trace("%s ", slot);
   if (op->cap_type)
     {


### PR DESCRIPTION
In bitops.h, update the TABLE macro to call snprintf(buf, sizeof(buf), ...) rather than unbounded sprintf, ensuring that out-of-range indices produce a bounded "??%d" string.

In setpci.c, change the device slot formatting from sprintf(slot, ...) to snprintf(slot, sizeof(slot), ...), capping output to the 16-byte buffer and avoiding overflow when printing PCI domain, bus, dev, and func values.