### PR TITLE
lib: handle NULL return from udev_hwdb_new() in hwdb lookup

### DIFF
--- a/lib/names-hwdb.c
+++ b/lib/names-hwdb.c
@@ -71,7 +71,16 @@ pci_id_hwdb_lookup(struct pci_access *a, int cat, int id1, int id2, int id3, int
 	{
 	  a->debug("Initializing UDEV HWDB\n");
 	  a->id_udev = udev_new();
-	  a->id_udev_hwdb = udev_hwdb_new(a->id_udev);
+	  if (a->id_udev)
+	    a->id_udev_hwdb = udev_hwdb_new(a->id_udev);
+	  if (!a->id_udev_hwdb)
+	    {
+	      a->debug("UDEV HWDB not available\n");
+	      if (a->id_udev)
+		udev_unref(a->id_udev);
+	      a->id_udev = NULL;
+	      return NULL;
+	    }
 	}
 
       struct udev_list_entry *entry;


### PR DESCRIPTION
udev_hwdb_new() can return NULL when hwdb.bin is not available on the system (e.g., inside flatpak or container runtimes where the hwdb database is not bundled).  Currently this NULL is passed directly to udev_hwdb_get_properties_list_entry() which calls assert_return_errno(hwdb, ...), causing an assertion failure and SIGABRT.

Additionally, udev_new() itself can return NULL (e.g., on OOM), which would then be passed to udev_hwdb_new().

Fix this by checking the return value of both udev_new() and udev_hwdb_new().  On failure, clean up any partially-initialized state and return NULL.  The caller in names.c already handles NULL return from pci_id_hwdb_lookup() by falling through to the next lookup method (pci.ids or network).

Reproducer:
  flatpak run --command=lspci net.lutris.Lutris
  -> Assertion 'hwdb' failed at src/libudev/libudev-hwdb.c:107,
     function udev_hwdb_get_properties_list_entry(). Aborting.