### PR TITLE
windows: Fix inverted version check in win32_is_vista_system()

### DIFF
--- a/lib/win32-helpers.c
+++ b/lib/win32-helpers.c
@@ -251,7 +251,7 @@ win32_is_vista_system(void)
   version.dwOSVersionInfoSize = sizeof(version);
   if (!GetVersionEx(&version) ||
       version.dwPlatformId != VER_PLATFORM_WIN32_NT ||
-      version.dwMajorVersion >= 6)
+      version.dwMajorVersion < 6)
     return FALSE;
   else
     return TRUE;


### PR DESCRIPTION
## Problem

The non-x86 (`#else`) branch of `win32_is_vista_system()` in `lib/win32-helpers.c` uses an inverted comparison:

```c
if (!GetVersionEx(&version) ||
    version.dwPlatformId != VER_PLATFORM_WIN32_NT ||
    version.dwMajorVersion >= 6)   /* inverted */
  return FALSE;
else
  return TRUE;
```

Windows Vista is NT 6.0, so "Vista or higher" must be TRUE when `dwMajorVersion >= 6`. The x86 branch is already correct (`(raw_version & 0xff) >= 6` → TRUE). As written, the x64 build reports every Vista-or-later system as pre-Vista.

## Impact

For `win32-kldbg` this is fatal: `win32_kldbg_setup()` does `if (!win32_is_vista_system())` and bails out with *"requires Windows Vista or higher version."* The Kernel Local Debugging Driver access method therefore never engages on 64-bit Windows, leaving PCIe extended config space — and thus Lane Margining via `pcilmr` — unreachable.

`open_process_for_query()` also relies on this helper, though it only degrades to `PROCESS_QUERY_INFORMATION` rather than failing outright.

## Fix

Test `dwMajorVersion < 6` instead. `GetVersionEx()` reports at most 6.2 without a compatibility manifest, but `< 6` is correct regardless of that cap.

## Testing

On Windows 11 x64 (MinGW-w64 UCRT build):

- **Before:** `lspci -A win32-kldbg` failed with *"requires Windows Vista or higher version."*
- **After:** the driver is unpacked from `kd.exe`, the `kldbgdrv` service starts, and config space is read successfully. `pcilmr --scan` then enumerates LMR-capable links and a full lane-margining run of a Gen4 x4 link completes with valid eye-width results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
