### PR TITLE
setpci: Variable Length & Runtime, Dynamic Length Discovery of Vendor Defined Capabilities

### DIFF
--- a/setpci.c
+++ b/setpci.c
@@ -8,16 +8,18 @@
  *	SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "lib/pci.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <strings.h>
 
 #define PCIUTILS_SETPCI
 #include "pciutils.h"
 
-#define MAX_SPLIT_WIDTH 4 /* Has to be 1, 2, or 4 (valid singular pci read or write size) */
+#define MAX_OP_WIDTH 4        /* Has to be 1, 2, or 4 (valid singular pci read size) */
 
 static int force;			/* Don't complain if no devices match */
 static int verbose;			/* Verbosity level */
@@ -41,7 +43,8 @@ struct op {
   unsigned int hdr_type_mask;
   unsigned int addr;
   unsigned int width;			/* Byte width of the access */
-  unsigned int span;            /* Width of variable-sized window in bytes (0 unless .V) */
+  int32_t span;                 /* Width of variable-sized window in bytes (0 unless .V) */
+  unsigned int auto_discov;     /* Dynamically determine the span at runtime? */
   unsigned int num_values;		/* Number of values to write; 0=read */
   unsigned int number;                 /* The n-th capability of that id */
   struct value values[0];
@@ -111,15 +114,38 @@ trace(const char *fmt, ...)
   va_end(args);
 }
 
+static u32
+auto_discov_len(struct pci_dev *dev, int addr, int shift)
+{
+  u32 header = pci_read_long(dev, addr);
+  return (header >> shift) & 0xfff;
+}
+
+static u32
+det_ext_cap_defined_length(struct pci_dev *dev, int cap_base, int cap_id, int cap_type)
+{
+  if (cap_type != PCI_CAP_EXTENDED)
+    die("Auto length only supports extended vendor-defined capabilities");
+
+  switch (cap_id)
+    {
+      case PCI_EXT_CAP_ID_DVSEC:
+      case PCI_EXT_CAP_ID_VNDR:
+        return auto_discov_len(dev, cap_base + 4, 20);
+      default:
+        die("Auto length not supported for this capability");
+    }
+}
+
 static unsigned int
 pci_read(struct pci_dev *dev, int addr, int w)
 {
   switch (w)
-  {
-    case 1:  return pci_read_byte(dev, addr);
-    case 2:  return pci_read_word(dev, addr);
-    default: return pci_read_long(dev, addr);
-  }
+    {
+      case 1:  return pci_read_byte(dev, addr);
+      case 2:  return pci_read_word(dev, addr);
+      default: return pci_read_long(dev, addr);
+    }
 }
 
 static unsigned int
@@ -137,9 +163,9 @@ static void
 print_le_bytes(u32 x, int width)
 {
   for (int b = 0; b < width; b++)
-  {
-    printf("%02x", (x >> (8 * b)) & 0xff);
-  }
+    {
+      printf("%02x", (x >> (8 * b)) & 0xff);
+    }
 }
 
 static void
@@ -150,7 +176,7 @@ exec_op(struct op *op, struct pci_dev *dev)
   unsigned int i, x, y;
   int addr = 0;
   int width = op->width;
-  int span = op->span;
+  int32_t span;
   char slot[16];
 
   snprintf(slot, sizeof(slot), "%04x:%02x:%02x.%x", dev->domain, dev->bus, dev->dev, dev->func);
@@ -177,13 +203,23 @@ exec_op(struct op *op, struct pci_dev *dev)
   addr += op->addr;
   trace("@%02x", addr);
 
+  if (op->auto_discov && !op->cap_type)
+    die("%s: Auto length requires a capability", slot);
+
+  span = op->auto_discov
+    ? op->span + (int32_t)det_ext_cap_defined_length(dev, addr - op->addr, op->cap_id, op->cap_type)
+    : op->span;
+
+  if (span < 0)
+    die("Span cannot be negative: \"%d\"", span);
+
   /* We have already checked it when parsing, but addressing relative to capabilities can change the address. */
   if (addr & (width-1))
     die("%s: Unaligned access of width %d to register %04x", slot, width, addr);
   if (addr + width > 0x1000)
     die("%s: Access of width %d to register %04x out of range", slot, width, addr);
   if (span && addr + span > 0x1000)
-    die("%s: Access of range %u to register %04x is out of range", slot, span, addr);
+    die("%s: Access of range %d to register %04x is out of range", slot, span, addr);
 
   if (op->hdr_type_mask)
     {
@@ -241,36 +277,25 @@ exec_op(struct op *op, struct pci_dev *dev)
     {
       trace(" = ");
       if (!span)
-      {
-        switch (width)
-	      {
-	        case 1:
-	          x = pci_read_byte(dev, addr);
-	          break;
-	        case 2:
-	          x = pci_read_word(dev, addr);
-	          break;
-	        default:
-	          x = pci_read_long(dev, addr);
-	          break;
-        }
-      printf(formats[width]+1, x);
-      putchar('\n');
-      }
-      else
-      {
-        int remaining = span;
-        while (remaining)
         {
-          width = determine_width_alignment(addr, remaining);
           x = pci_read(dev, addr, width);
-          print_le_bytes(x, width);
-          addr += width;
-          remaining -= width;
+          printf(formats[width]+1, x);
+          putchar('\n');
         }
+      else
+        {
+          int32_t remaining = span;
+          while (remaining)
+            {
+              width = determine_width_alignment(addr, remaining);
+              x = pci_read(dev, addr, width);
+              print_le_bytes(x, width);
+              addr += width;
+              remaining -= width;
+            }
 
-        putchar('\n');
-      }
+          putchar('\n');
+        }
     }
 }
 
@@ -494,14 +519,15 @@ GENERIC_HELP
 "Setting commands:\n"
 "<device>:\t-s [[[<domain>]:][<bus>]:][<slot>][.[<func>]]\n"
 "\t\t-d [<vendor>]:[<device>]\n"
-"<reg>:\t\t<base>[+<offset>][.(B|W|L|V[<length>])][@<number>]\n"
+"<reg>:\t\t<base>[+<offset>][.(B|W|L|V[<length>]|V)][@<number>]\n"
 "<base>:\t\t<address>\n"
 "\t\t<named-register>\n"
 "\t\t[E]CAP_<capability-name>\n"
 "\t\t[E]CAP<capability-number>\n"
 "<values>:\t<value>[,<value>...]\n"
 "<value>:\t<hex>\n"
-"<length>:\thex (number of bytes; multiple of split width)\n"
+"<length>:\t<hex> (number of bytes)\n"
+"V:\tdynamic, runtime discovery of header length\n"
 "\t\t<hex>:<mask>\n");
   exit(0);
 }
@@ -726,6 +752,7 @@ static void parse_op(char *c, struct group *group)
   char *span = NULL;
   int n, j;
   unsigned int span_val = 0;
+  unsigned int auto_discov = 0;
   struct op *op;
 
   /* Split the argument */
@@ -736,15 +763,34 @@ static void parse_op(char *c, struct group *group)
     *number++ = 0;
   if (width = strchr(base, '.'))
     *width++ = 0;
-  if (width && (span = strchr(width, '[')))
+  if (width)
     {
-      char *stop;
-      *span++ = 0;
-      if (parse_x32(span, &stop, &span_val) < 0 || !stop || *stop != ']' || stop[1])
-        parse_err("Invalid span \"%s\"", span);
-      if (span_val == 0) {
-        parse_err("Span must be a non-zero value. Span is: \"%d\"", span_val);
-      }
+      if (span = strchr(width, '['))
+        {
+          char *close;
+          *span++ = 0;
+
+          if (strcasecmp(width, "V"))
+            parse_err("Span is only allowed on the variable length operator \".V\"");
+
+          close = strchr(span, ']');
+          if (!close)
+            parse_err("Invalid span provided : \"%s\"", span);
+
+          if (close[1])
+            parse_err("Invalid characters placed after \"]\". Please use \".V\" or \".V[len]\"");
+
+          *close = 0;
+          if (parse_x32(span, NULL, &span_val) != 1)
+            parse_err("Invalid span provided: \"%s\"", span);
+          if (span_val == 0)
+            parse_err("Span must be a non-zero value. Span is: \"%d\"", span_val);
+        }
+      else if(!strcasecmp(width, "V"))
+        {
+          auto_discov = 1;
+          span = "V";
+        }
     }
   if (offset = strchr(base, '+'))
     *offset++ = 0;
@@ -762,9 +808,7 @@ static void parse_op(char *c, struct group *group)
     }
 
   if (span && n)
-  {
-    parse_err("Variable length (.V[N]) operations are a read only feature");
-  }
+    parse_err("Variable length (.V or .V[...]) is a read only feature");
 
   /* Allocate the operation */
   op = xmalloc(sizeof(struct op) + n*sizeof(struct value));
@@ -774,7 +818,7 @@ static void parse_op(char *c, struct group *group)
   op->num_values = n;
 
   /* What is the width suffix? */
-  if (width && !span)
+  if (width && strcasecmp(width, "V"))
     {
       if (width[1])
 	parse_err("Invalid width \"%s\"", width);
@@ -792,11 +836,18 @@ static void parse_op(char *c, struct group *group)
     }
   else if (span)
     {
-     if (!width || (*width & 0xdf) != 'V' || width[1])
-      parse_err("Invalid variable-width suffix; expected .V[N]");
+      if (!width || strncasecmp(width, "V", 1) || width[1])
+        parse_err("Invalid variable-width suffix; expected .V[N]");
 
-    op->width = MAX_SPLIT_WIDTH;
-    op->span = span_val;
+      if (auto_discov)
+        {
+          op->span = 0;
+          op->auto_discov = auto_discov;
+        }
+      else
+        op->span = span_val;
+
+      op->width = MAX_OP_WIDTH;
     }
   else
     op->width = 0;
@@ -825,10 +876,14 @@ static void parse_op(char *c, struct group *group)
       if (parse_x32(offset, NULL, &off) <= 0 || off >= 0x1000)
 	parse_err("Invalid offset \"%s\"", offset);
       op->addr += off;
+
+      /* Adjust for the provided offset in preparation for the auto-discovered, raw span */
+      if (auto_discov)
+        op->span -= off;
     }
 
   /* Check range */
-  unsigned int range_span = op->span ? op->span : op->width * (n ? n : 1);
+  unsigned int range_span = op->span ? (u32)op->span : op->width * (n ? n : 1);
   if (op->addr >= 0x1000 || op->addr + range_span > 0x1000)
     parse_err("Register number %02x out of range", op->addr);
   if (op->addr & (op->width - 1))

--- a/setpci.c
+++ b/setpci.c
@@ -17,6 +17,8 @@
 #define PCIUTILS_SETPCI
 #include "pciutils.h"
 
+#define MAX_SPLIT_WIDTH 4 /* Has to be 1, 2, or 4 (valid singular pci read or write size) */
+
 static int force;			/* Don't complain if no devices match */
 static int verbose;			/* Verbosity level */
 static int demo_mode;			/* Only show */
@@ -39,6 +41,7 @@ struct op {
   unsigned int hdr_type_mask;
   unsigned int addr;
   unsigned int width;			/* Byte width of the access */
+  unsigned int span;            /* Width of variable-sized window in bytes (0 unless .V) */
   unsigned int num_values;		/* Number of values to write; 0=read */
   unsigned int number;                 /* The n-th capability of that id */
   struct value values[0];
@@ -108,6 +111,37 @@ trace(const char *fmt, ...)
   va_end(args);
 }
 
+static unsigned int
+pci_read(struct pci_dev *dev, int addr, int w)
+{
+  switch (w)
+  {
+    case 1:  return pci_read_byte(dev, addr);
+    case 2:  return pci_read_word(dev, addr);
+    default: return pci_read_long(dev, addr);
+  }
+}
+
+static unsigned int
+determine_width_alignment(unsigned int addr, int remaining)
+{
+  if ((addr & 3) == 0 && remaining >= 4)
+    return 4;
+  if ((addr & 1) == 0 && remaining >= 2)
+    return 2;
+
+  return 1;
+}
+
+static void
+print_le_bytes(u32 x, int width)
+{
+  for (int b = 0; b < width; b++)
+  {
+    printf("%02x", (x >> (8 * b)) & 0xff);
+  }
+}
+
 static void
 exec_op(struct op *op, struct pci_dev *dev)
 {
@@ -116,6 +150,7 @@ exec_op(struct op *op, struct pci_dev *dev)
   unsigned int i, x, y;
   int addr = 0;
   int width = op->width;
+  int span = op->span;
   char slot[16];
 
   snprintf(slot, sizeof(slot), "%04x:%02x:%02x.%x", dev->domain, dev->bus, dev->dev, dev->func);
@@ -147,6 +182,8 @@ exec_op(struct op *op, struct pci_dev *dev)
     die("%s: Unaligned access of width %d to register %04x", slot, width, addr);
   if (addr + width > 0x1000)
     die("%s: Access of width %d to register %04x out of range", slot, width, addr);
+  if (span && addr + span > 0x1000)
+    die("%s: Access of range %u to register %04x is out of range", slot, span, addr);
 
   if (op->hdr_type_mask)
     {
@@ -203,20 +240,37 @@ exec_op(struct op *op, struct pci_dev *dev)
   else
     {
       trace(" = ");
-      switch (width)
-	{
-	case 1:
-	  x = pci_read_byte(dev, addr);
-	  break;
-	case 2:
-	  x = pci_read_word(dev, addr);
-	  break;
-	default:
-	  x = pci_read_long(dev, addr);
-	  break;
-	}
+      if (!span)
+      {
+        switch (width)
+	      {
+	        case 1:
+	          x = pci_read_byte(dev, addr);
+	          break;
+	        case 2:
+	          x = pci_read_word(dev, addr);
+	          break;
+	        default:
+	          x = pci_read_long(dev, addr);
+	          break;
+        }
       printf(formats[width]+1, x);
       putchar('\n');
+      }
+      else
+      {
+        int remaining = span;
+        while (remaining)
+        {
+          width = determine_width_alignment(addr, remaining);
+          x = pci_read(dev, addr, width);
+          print_le_bytes(x, width);
+          addr += width;
+          remaining -= width;
+        }
+
+        putchar('\n');
+      }
     }
 }
 
@@ -440,13 +494,14 @@ GENERIC_HELP
 "Setting commands:\n"
 "<device>:\t-s [[[<domain>]:][<bus>]:][<slot>][.[<func>]]\n"
 "\t\t-d [<vendor>]:[<device>]\n"
-"<reg>:\t\t<base>[+<offset>][.(B|W|L)][@<number>]\n"
+"<reg>:\t\t<base>[+<offset>][.(B|W|L|V[<length>])][@<number>]\n"
 "<base>:\t\t<address>\n"
 "\t\t<named-register>\n"
 "\t\t[E]CAP_<capability-name>\n"
 "\t\t[E]CAP<capability-number>\n"
 "<values>:\t<value>[,<value>...]\n"
 "<value>:\t<hex>\n"
+"<length>:\thex (number of bytes; multiple of split width)\n"
 "\t\t<hex>:<mask>\n");
   exit(0);
 }
@@ -668,7 +723,9 @@ static void parse_op(char *c, struct group *group)
 {
   char *base, *offset, *width, *value, *number;
   char *e, *f;
+  char *span = NULL;
   int n, j;
+  unsigned int span_val = 0;
   struct op *op;
 
   /* Split the argument */
@@ -679,6 +736,16 @@ static void parse_op(char *c, struct group *group)
     *number++ = 0;
   if (width = strchr(base, '.'))
     *width++ = 0;
+  if (width && (span = strchr(width, '[')))
+    {
+      char *stop;
+      *span++ = 0;
+      if (parse_x32(span, &stop, &span_val) < 0 || !stop || *stop != ']' || stop[1])
+        parse_err("Invalid span \"%s\"", span);
+      if (span_val == 0) {
+        parse_err("Span must be a non-zero value. Span is: \"%d\"", span_val);
+      }
+    }
   if (offset = strchr(base, '+'))
     *offset++ = 0;
 
@@ -694,6 +761,11 @@ static void parse_op(char *c, struct group *group)
 	  n++;
     }
 
+  if (span && n)
+  {
+    parse_err("Variable length (.V[N]) operations are a read only feature");
+  }
+
   /* Allocate the operation */
   op = xmalloc(sizeof(struct op) + n*sizeof(struct value));
   memset(op, 0, sizeof(struct op));
@@ -702,7 +774,7 @@ static void parse_op(char *c, struct group *group)
   op->num_values = n;
 
   /* What is the width suffix? */
-  if (width)
+  if (width && !span)
     {
       if (width[1])
 	parse_err("Invalid width \"%s\"", width);
@@ -716,7 +788,15 @@ static void parse_op(char *c, struct group *group)
 	  op->width = 4; break;
 	default:
 	  parse_err("Invalid width \"%c\"", *width);
-	}
+	  }
+    }
+  else if (span)
+    {
+     if (!width || (*width & 0xdf) != 'V' || width[1])
+      parse_err("Invalid variable-width suffix; expected .V[N]");
+
+    op->width = MAX_SPLIT_WIDTH;
+    op->span = span_val;
     }
   else
     op->width = 0;
@@ -748,7 +828,8 @@ static void parse_op(char *c, struct group *group)
     }
 
   /* Check range */
-  if (op->addr >= 0x1000 || op->addr + op->width*(n ? n : 1) > 0x1000)
+  unsigned int range_span = op->span ? op->span : op->width * (n ? n : 1);
+  if (op->addr >= 0x1000 || op->addr + range_span > 0x1000)
     parse_err("Register number %02x out of range", op->addr);
   if (op->addr & (op->width - 1))
     parse_err("Unaligned register address %02x", op->addr);

--- a/setpci.man
+++ b/setpci.man
@@ -157,15 +157,23 @@ To choose how many bytes (1, 2, or 4) should be transferred, you should append a
 specifier \fB.B\fP, \fB.W\fP, or \fB.L\fP. The width can be omitted if you are
 referring to a register by its name and the width of the register is well known.
 .IP \(bu
-To transfer a variable-length window larger than a single access, apend \fB.V[len]\fP,
+To operate on a variable-length window larger than a single access, append \fB.V[len]\fP,
 where \fBlen\fP is a hexademical byte count set statically within setpci (4). The window is read
-as a sequence of aligned longword accesses, low address first. Each chunk is assembled in
+as a sequence of aligned long accesses, low address first. Each chunk is assembled in
 little-endian, but the final result is in big-endian. This is the opposite of other operations.
-If there is a misalignment, that is fixed in the, first couple reads: we will do a two byte and
+If there is a misalignment, that is fixed in the first couple reads: we will do a two byte and
 a one byte read or one or the other to reach four-byte alignment, and then continue to read four
-bytes. Because PCI configuraiton space has no atomic access wider than a longword, a
+bytes. Because PCI configuration space has no atomic access wider than a long, a
 \fB.V[len]\fP operation is \fInot\fP atomic: if the underlying field changes between the
 individual accesses, the value may be read torn.
+.IP \(bu
+To use a variable-length window larger than a single access specifically for reads on vendor-defined
+registers / values, you can use .V. In this mode, setpci will, at runtime, dynamically
+determine the length defined within the vendor header. Note that this only works for
+vendor-defined registers like ECAP_DVSEC or ECAP_VNDR. Note that the way in which reading is done and
+the output is produced is the same as the non-automatic variable-length window. That means the
+result is returned in big-endian, which is the \fIopposite\fP of all other operation sizes.
+
 .IP \(bu
 Finally, if a capability exists multiple times you can choose which one to target using
 \fB@number\fP. Indexing starts at 0.
@@ -192,6 +200,15 @@ asks for the first 32-bit word of the extended capability with ID 0x108.
 .IP ECAP_DSN+4.V[8]
 reads the 8-byte Device Serial Number as a single little-endian value,
 equivalent to reading the longwords at \fB+4\fP and \fB+8\fP and combining them.
+reads starting from the offset provided.
+.IP ECAP_DVSEC.V
+resolves the DVSEC capability on the device, reads DVSEC header 1 at base+4,
+extracts the length and reads as many bytes.
+.IP ECAP_VNDR+4.V
+resolves the Vendor specific capbaility on the device, reads the VSEC header,
+extracst the length and reads as many bytes within the span found.
+reads from the provided offset, automatically adjusting the total span to read with respect
+to the adjusted starting position
 
 .SH SEE ALSO
 .BR lspci (8),

--- a/setpci.man
+++ b/setpci.man
@@ -157,6 +157,16 @@ To choose how many bytes (1, 2, or 4) should be transferred, you should append a
 specifier \fB.B\fP, \fB.W\fP, or \fB.L\fP. The width can be omitted if you are
 referring to a register by its name and the width of the register is well known.
 .IP \(bu
+To transfer a variable-length window larger than a single access, apend \fB.V[len]\fP,
+where \fBlen\fP is a hexademical byte count set statically within setpci (4). The window is read
+as a sequence of aligned longword accesses, low address first. Each chunk is assembled in
+little-endian, but the final result is in big-endian. This is the opposite of other operations.
+If there is a misalignment, that is fixed in the, first couple reads: we will do a two byte and
+a one byte read or one or the other to reach four-byte alignment, and then continue to read four
+bytes. Because PCI configuraiton space has no atomic access wider than a longword, a
+\fB.V[len]\fP operation is \fInot\fP atomic: if the underlying field changes between the
+individual accesses, the value may be read torn.
+.IP \(bu
 Finally, if a capability exists multiple times you can choose which one to target using
 \fB@number\fP. Indexing starts at 0.
 
@@ -179,6 +189,9 @@ specifies the upper byte of the vendor ID register (remember, PCI is little-endi
 corresponds to the second word of the power management capability.
 .IP ECAP108.l
 asks for the first 32-bit word of the extended capability with ID 0x108.
+.IP ECAP_DSN+4.V[8]
+reads the 8-byte Device Serial Number as a single little-endian value,
+equivalent to reading the longwords at \fB+4\fP and \fB+8\fP and combining them.
 
 .SH SEE ALSO
 .BR lspci (8),

--- a/setpci.man
+++ b/setpci.man
@@ -158,22 +158,14 @@ specifier \fB.B\fP, \fB.W\fP, or \fB.L\fP. The width can be omitted if you are
 referring to a register by its name and the width of the register is well known.
 .IP \(bu
 To operate on a variable-length window larger than a single access, append \fB.V[len]\fP,
-where \fBlen\fP is a hexademical byte count set statically within setpci (4). The window is read
-as a sequence of aligned long accesses, low address first. Each chunk is assembled in
-little-endian, but the final result is in big-endian. This is the opposite of other operations.
-If there is a misalignment, that is fixed in the first couple reads: we will do a two byte and
-a one byte read or one or the other to reach four-byte alignment, and then continue to read four
-bytes. Because PCI configuration space has no atomic access wider than a long, a
-\fB.V[len]\fP operation is \fInot\fP atomic: if the underlying field changes between the
-individual accesses, the value may be read torn.
+where \fBlen\fP is a hexademical byte count set statically within setpci (4). The requested
+number of bytes is printed out in a bite wise fashion with read width and alignment
+being handled internally. Note that this is a non-atomic operation and the result is printed
+in big-endian--opposite of all other operations.
 .IP \(bu
 To use a variable-length window larger than a single access specifically for reads on vendor-defined
-registers / values, you can use .V. In this mode, setpci will, at runtime, dynamically
-determine the length defined within the vendor header. Note that this only works for
-vendor-defined registers like ECAP_DVSEC or ECAP_VNDR. Note that the way in which reading is done and
-the output is produced is the same as the non-automatic variable-length window. That means the
-result is returned in big-endian, which is the \fIopposite\fP of all other operation sizes.
-
+registers / values, you can use .V. Setpci will determine the length at runtime, adjust for any
+offsets provided, and then perform a read with the same semantics as .V[len].
 .IP \(bu
 Finally, if a capability exists multiple times you can choose which one to target using
 \fB@number\fP. Indexing starts at 0.


### PR DESCRIPTION
This updates specifically setpci's reads to be able to handle variable-length reads and do dynamic, runtime discovery of vendor-defined capabilities' lengths, removing the need for users to know the length at the invocation of setpci.

**Note**: in order to not tear, we ensure that we are four-byte aligned _before_ reading any information, and then do four byte reads from there on out. This means that we might start with a two byte or one byte read, before doing four byte reads.

**Note**: the final result returned by a variable-length read is always in big-endian.

Variable-length reads:
- Syntax: `.V[N]`
- Semantics: N is defined in hex and represents the total length of the information that the user would like to read, starting from the initial address to the end of the read
- Any time arguments are provided for a write to occur with variable-length reads, an error is thrown

Auto-defined reads:
- Syntax: `.V`
- Semantics: when auto is provided, setpci first checks that the provided capability is a vendor-defined capability, such that the header contains a length field (non-vendor defined capabilities where the length is not truly dynamic do not contain a length field and thus this would read and rely on garbage data) and then reads the length out of the header, storing that within the `span` variable and performing a normal, variable-length read from there

Background:

It would be nice to be able to perform larger reads in a single operation, rather than having to list out all of the offsets and read sizes by hand. This is especially useful for static fields, like DSN, where the operation is larger than four bytes, but we never expect the DSN to change, and thus we have next to no risk of tearing. This can also extremely helpful for vendor-defined capabilities, where users no longer have to read the length from `lspci`, and can simply supply the name of the capability with or without an offset to get the answer they want (e.g. ECAP_VNDR.V or ECAP_VNDR+4.V).